### PR TITLE
[XueXiT]适配AI答题

### DIFF
--- a/aggregation/yinghua/YingHuaCourseAction.go
+++ b/aggregation/yinghua/YingHuaCourseAction.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/yatori-dev/yatori-go-core/api/entity"
 	"math/rand"
 	"os"
 	"regexp"
@@ -281,7 +282,7 @@ func ExamDetailAction(UserCache *yinghuaApi.YingHuaUserCache, nodeId string) ([]
 }
 
 // randomAnswer 如果AI出问题那么直接随机返回答案
-func randomAnswer(topic yinghuaApi.YingHuaExamTopic) string {
+func randomAnswer(topic entity.YingHuaExamTopic) string {
 	if topic.Type == "单选" {
 		sct := rand.Intn(len(topic.Selects))
 		return "[" + topic.Selects[sct].Value + "]"
@@ -329,7 +330,9 @@ func StartExamAction(
 	var lastProblem string
 	for k, v := range topic.YingHuaExamTopics {
 		//构建统一AI消息
-		aiMessage := yinghuaApi.AIProblemMessage(exam.Title, v)
+		aiMessage := yinghuaApi.AIProblemMessage(exam.Title, entity.ExamTurn{
+			YingHuaExamTopic: v,
+		})
 		aiAnswer, err := utils.AggregationAIApi(url, model, aiType, aiMessage, apiKey)
 		answer := aiTurnYingHuaAnswer(userCache, aiAnswer, v)
 
@@ -432,7 +435,7 @@ func selectMarkingSystem(text1, text2 string) float32 {
 // 竞争对手之间有激烈的价格竞争
 // 竞争对手之间有激烈的价格竞争
 // AI回复转答案
-func aiTurnYingHuaAnswer(cache *yinghuaApi.YingHuaUserCache, aiAnswer string, v yinghuaApi.YingHuaExamTopic) yinghuaApi.YingHuaAnswer {
+func aiTurnYingHuaAnswer(cache *yinghuaApi.YingHuaUserCache, aiAnswer string, v entity.YingHuaExamTopic) yinghuaApi.YingHuaAnswer {
 	answer := yinghuaApi.YingHuaAnswer{Type: v.Type}
 	if v.Type == "单选" || v.Type == "判断" || v.Type == "多选" {
 		var jsonStr []string
@@ -510,7 +513,9 @@ func StartWorkAction(userCache *yinghuaApi.YingHuaUserCache,
 	var lastProblem string
 	for k, v := range topic.YingHuaExamTopics {
 		//构建统一AI消息
-		aiMessage := yinghuaApi.AIProblemMessage(work.Title, v)
+		aiMessage := yinghuaApi.AIProblemMessage(work.Title, entity.ExamTurn{
+			YingHuaExamTopic: v,
+		})
 		aiAnswer, err := utils.AggregationAIApi(url, model, aiType, aiMessage, apiKey)
 		answer := aiTurnYingHuaAnswer(userCache, aiAnswer, v)
 

--- a/api/entity/CardEntity.go
+++ b/api/entity/CardEntity.go
@@ -251,7 +251,11 @@ func (p *PointDocumentDto) AttachmentsDetection(attachment interface{}) (bool, e
 			objectid := property["objectid"]
 			if objectid == p.ObjectID {
 				p.Title = property["name"].(string)
-				p.JobID = property["jobid"].(string)
+				if property["jobid"] == nil {
+					p.JobID = ""
+				} else {
+					p.JobID = property["jobid"].(string)
+				}
 				p.Jtoken = att["jtoken"].(string)
 			}
 		}

--- a/api/entity/CourseEntity.go
+++ b/api/entity/CourseEntity.go
@@ -1,5 +1,12 @@
 package entity
 
+import (
+	"github.com/yatori-dev/yatori-go-core/models/ctype"
+	"github.com/yatori-dev/yatori-go-core/utils"
+	"github.com/yatori-dev/yatori-go-core/utils/log"
+	"os"
+)
+
 // XueXiTCourse 课程所有信息
 type XueXiTCourseJson struct {
 	Result           int           `json:"result"`
@@ -64,4 +71,58 @@ type XueXiTCourse struct {
 	Cpi        string //不知道是啥玩意，反正需要
 	PersonId   string //个人Id
 	UserId     string //UserId
+}
+
+// ExamTopics holds a map of ExamTopic indexed by answerId
+type YingHuaExamTopics struct {
+	YingHuaExamTopics map[string]YingHuaExamTopic
+}
+
+// ExamTopic represents a single exam question
+type YingHuaExamTopic struct {
+	AnswerId string        `json:"answerId"`
+	Index    string        `json:"index"`
+	Source   string        `json:"source"`
+	Content  string        `json:"content"`
+	Type     string        `json:"type"`
+	Selects  []TopicSelect `json:"selects"`
+	Answers  string        `json:"answers"`
+}
+
+// TopicSelect represents a possible answer choice
+type TopicSelect struct {
+	Value string `json:"value"`
+	Num   string `json:"num"`
+	Text  string `json:"text"`
+}
+
+type ChoiceQue struct {
+	Type    ctype.QueType
+	Text    string
+	Options map[string]string
+	Answer  string // 答案
+}
+
+// Question TODO 这里考虑是否在其中直接将答案做出 直接上报提交 或 保存提交
+type Question struct {
+	Choice []ChoiceQue //选择类型
+}
+
+type ExamTurn struct {
+	ChoiceQue
+	YingHuaExamTopic
+}
+
+func (q *ChoiceQue) AnswerAIGet(userID string,
+	url,
+	model string,
+	aiType ctype.AiType,
+	aiChatMessages utils.AIChatMessages,
+	apiKey string) {
+	aiAnswer, err := utils.AggregationAIApi(url, model, aiType, aiChatMessages, apiKey)
+	if err != nil {
+		log.Print(log.INFO, `[`, userID, `] `, log.BoldRed, "Ai异常，返回信息：", err.Error())
+		os.Exit(0)
+	}
+	q.Answer = aiAnswer
 }

--- a/api/internal/AiExamTurn.go
+++ b/api/internal/AiExamTurn.go
@@ -1,0 +1,10 @@
+package internal
+
+import (
+	"github.com/yatori-dev/yatori-go-core/api/entity"
+	"github.com/yatori-dev/yatori-go-core/utils"
+)
+
+type AiExamTurnInterface interface {
+	AIProblemMessage(testPaperTitle string, topic entity.ExamTurn) utils.AIChatMessages
+}

--- a/api/xuexitong/XueXiTongLoginApi.go
+++ b/api/xuexitong/XueXiTongLoginApi.go
@@ -31,7 +31,8 @@ const (
 	// APIChapterCardResource 接口-课程章节卡片资源
 	APIChapterCardResource = "https://mooc1-api.chaoxing.com/ananas/status"
 	// APIVideoPlayReport 接口-视频播放上报
-	APIVideoPlayReport = "https://mooc1.chaoxing.com/mooc-ans/multimedia/log/a"
+	APIVideoPlayReport  = "https://mooc1.chaoxing.com/mooc-ans/multimedia/log/a"
+	APIVideoPlayReport2 = "https://mooc1-api.chaoxing.com/multimedia/log/a" // cxkitty的
 
 	// ApiWorkCommit 接口-单元作业答题提交
 	ApiWorkCommit = "https://mooc1-api.chaoxing.com/work/addStudentWorkNew"


### PR DESCRIPTION
为`XueXiTo`后续适配ai答题 提交接口适配
也算是action的一种组合形式
将`Yinghua`的Ai答题提取到entity中做整体处理 添加
```go
type AiExamTurnInterface interface {
	AIProblemMessage(testPaperTitle string, topic entity.ExamTurn) utils.AIChatMessages
}
```
 避免每个课程端口都得独立书写