### PR TITLE
统一管理User-Agent

### DIFF
--- a/api/cqie/CqieCourseApi.go
+++ b/api/cqie/CqieCourseApi.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 // UserDetailsApi 获取用户信息
@@ -24,7 +26,7 @@ func (cache *CqieUserCache) UserDetailsApi(retry int, lastErr error) (string, er
 		return cache.UserDetailsApi(retry-1, err)
 	}
 	req.Header.Add("Authorization", cache.access_token)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.cqie.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -74,7 +76,7 @@ func (cache *CqieUserCache) PullCourseListApi(retry int, lastErr error) (string,
 		return cache.PullCourseListApi(retry-1, err)
 	}
 	req.Header.Add("Authorization", cache.access_token)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.cqie.edu.cn")
@@ -111,7 +113,7 @@ func (cache *CqieUserCache) GetVideoStudyIdApi(studentCourseId, videoId string, 
 		return cache.GetVideoStudyIdApi(studentCourseId, videoId, retry-1, lastErr)
 	}
 	req.Header.Add("Authorization", cache.access_token)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -175,7 +177,7 @@ func (cache *CqieUserCache) SubmitStudyTimeApi(
 	}
 	req.Header.Add("Authorization", cache.GetAccess_Token())
 	req.Header.Add("Cookie", cache.GetCookie())
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := client.Do(req)
@@ -222,7 +224,7 @@ func (cache *CqieUserCache) SaveStudyTimeApi(courseId, studentCourseId, unitId, 
 		return cache.SaveStudyTimeApi(courseId, studentCourseId, unitId, videoId, coursewareId, startPos, stopPos, retry-1, err)
 	}
 	req.Header.Add("Authorization", cache.access_token)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := client.Do(req)
@@ -256,7 +258,7 @@ func (cache *CqieUserCache) PullCourseDetailApi(courseId, studentCourseId string
 		return cache.PullCourseDetailApi(courseId, studentCourseId, retry-1, lastErr)
 	}
 	req.Header.Add("Authorization", cache.access_token)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -289,7 +291,7 @@ func (cache *CqieUserCache) PullProgressDetailApi(courseId, studentCourseId stri
 		return cache.PullProgressDetailApi(courseId, studentCourseId, retry-1, lastErr)
 	}
 	req.Header.Add("Authorization", cache.access_token)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/api/cqie/CqieLoginApi.go
+++ b/api/cqie/CqieLoginApi.go
@@ -51,7 +51,7 @@ func (cache *CqieUserCache) VerificationCodeApi() (string, string) {
 		fmt.Println(err)
 		return "", ""
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -97,7 +97,7 @@ func (cache *CqieUserCache) LoginApi() (string, error) {
 		fmt.Println(err)
 		return "", err
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Content-Type", "application/json")
 
 	res, err := client.Do(req)

--- a/api/enaea/EnaeaApi.go
+++ b/api/enaea/EnaeaApi.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 type EnaeaUserCache struct {
@@ -38,7 +40,7 @@ func LoginApi(cache *EnaeaUserCache) (string, error) {
 	}
 
 	req.Header.Add("Referer", "https://study.enaea.edu.cn/login.do")
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "passport.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -84,7 +86,7 @@ func PullProjectsApi(cache *EnaeaUserCache) (string, error) {
 
 	// Add headers
 	req.Header.Add("Cookie", "ASUSS="+cache.asuss+";")
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -116,7 +118,7 @@ func PullStudyCourseHTMLApi(cache *EnaeaUserCache, circleId string) (string, err
 
 	// Set the headers
 	req.Header.Add("Cookie", "ASUSS="+cache.asuss+";")
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -156,7 +158,7 @@ func PullStudyCourseListApi(cache *EnaeaUserCache, circleId, syllabusId, moudle 
 
 	// Set headers
 	req.Header.Add("Cookie", "ASUSS="+cache.asuss+";")
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -190,7 +192,7 @@ func PullCourseVideoListApi(cache *EnaeaUserCache, circleId, courseId string) (s
 
 	// Add headers
 	req.Header.Add("Cookie", "ASUSS="+cache.asuss+";")
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -225,7 +227,7 @@ func StatisticTicForCCVideApi(cache *EnaeaUserCache, courseId, courseContentId, 
 
 	// Add headers
 	req.Header.Add("Cookie", "ASUSS="+cache.asuss+";")
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -276,7 +278,7 @@ func SubmitStudyTimeApi(cache *EnaeaUserCache, circleId, SCFUCKPKey, SCFUCKPValu
 	// Add headers
 	cookie := fmt.Sprintf("ASUSS=%s;%s=%s", cache.asuss, SCFUCKPKey, SCFUCKPValue)
 	req.Header.Add("Cookie", cookie)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -324,7 +326,7 @@ func SubmitStudyTimeFastApi(cache *EnaeaUserCache, circleId, SCFUCKPKey, SCFUCKP
 	// Add headers
 	cookie := fmt.Sprintf("ASUSS=%s;%s=%s", cache.asuss, SCFUCKPKey, SCFUCKPValue)
 	req.Header.Add("Cookie", cookie)
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -370,7 +372,7 @@ func PullExamListApi(cache *EnaeaUserCache, circleId, syllabusId, moudle string)
 
 	// Set headers
 	req.Header.Add("Cookie", "ASUSS="+cache.asuss+";")
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "study.enaea.edu.cn")
 	req.Header.Add("Connection", "keep-alive")

--- a/api/gongxue/service/gongxueyun_service/logic.go
+++ b/api/gongxue/service/gongxueyun_service/logic.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 func (m *MoguDing) Run(runType string) {
@@ -57,7 +58,7 @@ const (
 
 var (
 	headers = map[string][]string{
-		"User-Agent":   {"Mozilla/5.0 (Linux; U; Android 9; zh-cn; Redmi Note 5 Build/PKQ1.180904.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/11.10.8"},
+		"User-Agent":   {utils.DefaultUserAgent},
 		"Content-Type": {"application/json; charset=UTF-8"},
 		"host":         {"api.moguding.net:9000"},
 	}

--- a/api/icve/IcveCourseApi.go
+++ b/api/icve/IcveCourseApi.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 // CourseListApi 拉取课程
@@ -22,7 +24,7 @@ func (cache *IcveUserCache) CourseListApi() {
 		fmt.Println(err)
 		return
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "mooc.icve.com.cn")

--- a/api/icve/IcveLoginApi.go
+++ b/api/icve/IcveLoginApi.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 type IcveUserCache struct {
@@ -31,7 +33,7 @@ func (cache *IcveUserCache) IcveLoginApi() error {
 		fmt.Println(err)
 		return err
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "sso.icve.com.cn")

--- a/api/ttcdw/TtcdwCourse.go
+++ b/api/ttcdw/TtcdwCourse.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 // 拉取所有项目
@@ -31,7 +33,7 @@ func (cache *TtcdwUserCache) PullProjectApi(retry int, lastErr error) (string, e
 	for _, v := range cache.cookies {
 		req.AddCookie(v)
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "www.ttcdw.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -66,7 +68,7 @@ func (cache *TtcdwUserCache) PullClassRoomApi(courseProjectId string, classId st
 	if err != nil {
 		return "", err
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "www.ttcdw.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -96,7 +98,7 @@ func (cache *TtcdwUserCache) PullCourseInfoApi(segmentId, courseId string, retry
 	if err != nil {
 		return "", nil
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "www.ttcdw.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -134,7 +136,7 @@ func (cache *TtcdwUserCache) PullCourseApi(segmentId, itemId string, retry int, 
 	for _, v := range cache.cookies {
 		req.AddCookie(v)
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "www.ttcdw.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -170,7 +172,7 @@ func (cache *TtcdwUserCache) PullChapterListHtmlApi(cid string, retry int, lastE
 	for _, v := range cache.cookies {
 		req.AddCookie(v)
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "service.icourses.cn")
 	req.Header.Add("Connection", "keep-alive")
@@ -204,7 +206,7 @@ func (cache *TtcdwUserCache) PullGetResApi(sectionId string, retry int, lastErr 
 	if err != nil {
 		return "", err
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "service.icourses.cn")
 	req.Header.Add("Connection", "keep-alive")

--- a/api/ttcdw/TtcdwLogin.go
+++ b/api/ttcdw/TtcdwLogin.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/thedevsaddam/gojsonq"
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 type TtcdwUserCache struct {
@@ -38,7 +39,7 @@ func (cache *TtcdwUserCache) TtcdwLoginApi() error {
 		fmt.Println(err)
 		return err
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "www.ttcdw.cn")
 	req.Header.Add("Connection", "keep-alive")

--- a/api/yinghua/YingHuaApi.go
+++ b/api/yinghua/YingHuaApi.go
@@ -114,7 +114,7 @@ func (cache *YingHuaUserCache) LoginApi(retry int, lastError error) (string, err
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	res, err := client.Do(req)
@@ -176,7 +176,7 @@ func (cache *YingHuaUserCache) VerificationCodeApi(retry int) (string, string) {
 		fmt.Println(err)
 		return "", ""
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	//req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/*,*/*;q=0.8")
 	//req.Header.Set("Referer", "https://bwgl.qiankj.com/")
 	req.Header.Set("Connection", "keep-alive")
@@ -263,7 +263,7 @@ func KeepAliveApi(cache YingHuaUserCache, retry int) string {
 		fmt.Println(err)
 		return ""
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
@@ -334,7 +334,7 @@ func (cache *YingHuaUserCache) CourseListApi(retry int, lastError error) (string
 		return "", err
 	}
 	req.Header.Add("Cookie", "tgw_I7_route=3d5c4e13e7d88bb6849295ab943042a2")
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	res, err := client.Do(req)
@@ -413,7 +413,7 @@ func (cache *YingHuaUserCache) CourseDetailApi(courseId string, retry int, lastE
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	res, err := client.Do(req)
@@ -483,7 +483,7 @@ func CourseVideListApi(cache YingHuaUserCache, courseId string /*课程ID*/, ret
 		time.Sleep(time.Millisecond * 150) //延迟
 		return CourseVideListApi(cache, courseId, retry-1, err)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
@@ -557,7 +557,7 @@ func SubmitStudyTimeApi(cache YingHuaUserCache, nodeId string /*对应视屏节�
 		//fmt.Println(err)
 		return "", err
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
@@ -627,7 +627,7 @@ func (cache *YingHuaUserCache) VideStudyTimeApi(nodeId string, retryNum int, las
 		time.Sleep(time.Millisecond * 150) //延迟
 		return cache.VideStudyTimeApi(nodeId, retryNum-1, lastError)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
@@ -694,7 +694,7 @@ func VideWatchRecodeApi(cache YingHuaUserCache, courseId string, page int, retry
 		//fmt.Println(err)
 		return VideWatchRecodeApi(cache, courseId, page, retry-1, err)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
@@ -753,7 +753,7 @@ func VideoWatchRecodePCListApi(cache YingHuaUserCache, courseId string, page int
 		//fmt.Println(err)
 		return VideoWatchRecodePCListApi(cache, courseId, page, retry-1, err)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -821,7 +821,7 @@ func ExamDetailApi(cache YingHuaUserCache, nodeId string, retryNum int, lastErro
 		fmt.Println(err)
 		return "", nil
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	res, err := client.Do(req)
@@ -877,7 +877,7 @@ func StartExam(cache YingHuaUserCache, courseId, nodeId, examId string, retryNum
 		time.Sleep(100 * time.Millisecond)
 		return StartExam(cache, courseId, nodeId, examId, retryNum-1, err)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	for _, cookie := range cache.cookies {
 		req.AddCookie(cookie)
 	}
@@ -938,7 +938,7 @@ func GetExamTopicApi(cache YingHuaUserCache, nodeId, examId string, retryNum int
 	}
 
 	// Set the headers
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", cache.PreUrl)
 	req.Header.Add("Connection", "keep-alive")
@@ -1030,7 +1030,7 @@ func SubmitExamApi(cache YingHuaUserCache, examId, answerId string, answers qent
 	}
 
 	// Set the headers
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", cache.PreUrl)
 	req.Header.Add("Connection", "keep-alive")
@@ -1107,7 +1107,7 @@ func WorkDetailApi(cache YingHuaUserCache, nodeId string, retryNum int, lastErro
 		fmt.Println(err)
 		return "", err
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	res, err := client.Do(req)
@@ -1160,7 +1160,7 @@ func StartWork(userCache YingHuaUserCache, courseId, nodeId, workId string, retr
 		fmt.Println(err)
 		return "", nil
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	for _, cookie := range userCache.cookies {
 		req.AddCookie(cookie)
 	}
@@ -1221,7 +1221,7 @@ func GetWorkApi(UserCache YingHuaUserCache, nodeId, workId string, retryNum int,
 		fmt.Println(err)
 		return "", nil
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	for _, cookie := range UserCache.cookies {
 		req.AddCookie(cookie)
@@ -1323,7 +1323,7 @@ func SubmitWorkApi(cache YingHuaUserCache, workId, answerId string, answers qent
 	}
 
 	// Set the headers
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", cache.PreUrl)
 	req.Header.Add("Connection", "keep-alive")
@@ -1384,7 +1384,7 @@ func WorkedFinallyDetailApi(userCache YingHuaUserCache, courseId, nodeId, workId
 	for _, cookie := range userCache.cookies {
 		req.AddCookie(cookie)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -1440,7 +1440,7 @@ func ExamFinallyDetailApi(userCache YingHuaUserCache, courseId, nodeId, workId s
 	for _, cookie := range userCache.cookies {
 		req.AddCookie(cookie)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/api/zhihuishu/ZhiHuiShuApi.go
+++ b/api/zhihuishu/ZhiHuiShuApi.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/thedevsaddam/gojsonq"
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 func GetValidate() string {
@@ -59,7 +60,7 @@ func ZhidaoQrCode() (string, string, error) {
 		fmt.Println(err)
 		return "", "", err
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "passport.zhihuishu.com")
 	req.Header.Add("Connection", "keep-alive")
@@ -94,7 +95,7 @@ func ZhidaoQrCheck(qrToken string) (string, error) {
 		fmt.Println(err)
 		return "", err
 	}
-	req.Header.Add("User-Agent", "Apifox/1.0.0 (https://apifox.com)")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "passport.zhihuishu.com")
 	req.Header.Add("Connection", "keep-alive")

--- a/examples/yatori_core_test.go
+++ b/examples/yatori_core_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yatori-dev/yatori-go-core/common"
 	"github.com/yatori-dev/yatori-go-core/global"
+	"github.com/yatori-dev/yatori-go-core/utils"
 )
 
 func setup() {
@@ -67,7 +68,7 @@ func TestProxyIp(t *testing.T) {
 	}
 
 	// 设置 User-Agent 等头信息（根据需求）
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36")
+	req.Header.Set("User-Agent", utils.DefaultUserAgent)
 
 	// 执行请求
 	resp, err := client.Do(req)

--- a/examples/yidun_test.go
+++ b/examples/yidun_test.go
@@ -311,7 +311,7 @@ func Test_yidun(t *testing.T) {
 	d := NewDun163("17c07e34e0384612bb239568b6b37643",
 		"https://id.163.com/mail/retrievepassword",
 		"app.miit-eidc.org.cn",
-		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36")
+		utils.DefaultUserAgent,)
 
 	if err := d.CompileJS("dun163.js"); err != nil {
 		panic(err)

--- a/examples/yinghua_test.go
+++ b/examples/yinghua_test.go
@@ -355,7 +355,7 @@ func TestApi(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	req.Header.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0")
+	req.Header.Add("User-Agent", utils.DefaultUserAgent)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -380,7 +380,7 @@ func TestCapterImg(t *testing.T) {
 	}
 
 	// 设置真实浏览器常见的 User-Agent
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36")
+	req.Header.Set("User-Agent", utils.DefaultUserAgent)
 	req.Header.Set("Accept", "image/avif,image/webp,image/apng,image/*,*/*;q=0.8")
 	req.Header.Set("Referer", "https://bwgl.qiankj.com/")
 	req.Header.Set("Connection", "keep-alive")

--- a/utils/HttpUtils.go
+++ b/utils/HttpUtils.go
@@ -2,6 +2,11 @@ package utils
 
 import "net/http"
 
+// 常用的User-Agent
+const (
+	DefaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0"
+)
+
 // 添加Cookies，并且是无重复添加，意思就是添加到目标Cookies里面时会检测是否有重复Key的Cookie，如果有则直接替换Cookie值
 func CookiesAddNoRepetition(addTarget *[]*http.Cookie, oldTarget []*http.Cookie) {
 	for i := range oldTarget {


### PR DESCRIPTION
项目中多处使用硬编码的User-Agent: `Apifox/1.0.0 (https://apifox.com)`，容易触发风控或被WAF拦截

此commit将`User-Agent`移动到`utils/HttpUtils.go`中，使用常见的浏览器标识符替换，便于统一修改和管理