### PR TITLE
fix: XueXiTong doHomeWork parser + MiniMax OTHER compatibility

### DIFF
--- a/aggregation/xuexitong/XuXiTongWorkAction.go
+++ b/aggregation/xuexitong/XuXiTongWorkAction.go
@@ -446,6 +446,31 @@ func HtmlWorkQuestionTurnEntity(paperHtml string) (XXTWorkQuestion, error) {
 	return question, nil
 }
 
+// 提取作业题干（避免把选项 .workWrap 误当题干）
+func extractWorkTitle(sel *goquery.Selection) string {
+	titleSel := sel.Find(`div.ans-cc.timuStyle.fontLabel.workWrap`).First()
+	if titleSel.Length() == 0 {
+		titleSel = sel.Find(`div.ans-cc.workWrap`).First()
+	}
+	if titleSel.Length() == 0 {
+		titleSel = sel.Find(`.workWrap`).First()
+	}
+	if titleSel.Length() == 0 {
+		return ""
+	}
+	return extractQuestion(titleSel)
+}
+
+// 提取选项文本（兼容 div.centerSpan / p 文本）
+func extractWorkOptionText(sel *goquery.Selection) string {
+	text := strings.TrimSpace(sel.Text())
+	if text == "" {
+		text = strings.TrimSpace(sel.Find("p").Text())
+	}
+	text = regexp.MustCompile(`\s+`).ReplaceAllString(text, " ")
+	return strings.TrimSpace(text)
+}
+
 // 单选题转换
 func singleWorkTurn(paperDoc *goquery.Document) (XXTWorkQuestion, error) {
 	question := XXTWorkQuestion{}
@@ -458,29 +483,25 @@ func singleWorkTurn(paperDoc *goquery.Document) (XXTWorkQuestion, error) {
 			//fmt.Println("question:", questionId)
 		}
 
-		//题目
-		//title := strings.TrimSpace(sel.Find(`.workWrap p`).First().Text())
-		title := ""
-		//截取题目
-		sel.Find(`.workWrap`).Each(func(i int, sel *goquery.Selection) {
-			title = extractQuestion(sel)
-		})
-		//fmt.Println(title)
-		question.Question.Content = title
+		// 题干（仅取题干节点）
+		question.Question.Content = extractWorkTitle(sel)
+
 		resOptions := make(map[string]string)
 		sel.Find(`div.centerSpan`).Each(func(i int, sel *goquery.Selection) {
-			//letter := strings.TrimSpace(sel.Find(`.No`).Text())
 			letter, _ := sel.Attr("id")
-			text := strings.TrimSpace(sel.Find(`p`).Text())
-			resOptions[letter] = letter + text
-			//fmt.Println(letter, text)
+			text := extractWorkOptionText(sel)
+			if letter == "" || text == "" {
+				return
+			}
+			resOptions[letter] = text
 		})
 		resSelect := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"}
 		for _, slt := range resSelect {
-			if resOptions[slt] == "" {
+			v, ok := resOptions[slt]
+			if !ok || v == "" {
 				break
 			}
-			question.Question.Options = append(question.Question.Options, resOptions[slt])
+			question.Question.Options = append(question.Question.Options, v)
 		}
 	})
 	return question, nil
@@ -498,29 +519,25 @@ func multipleWorkTurn(paperDoc *goquery.Document) (XXTWorkQuestion, error) {
 			//fmt.Println("question:", questionId)
 		}
 
-		//题目
-		//title := strings.TrimSpace(sel.Find(`.workWrap p`).First().Text())
-		title := ""
-		//截取题目
-		sel.Find(`.workWrap`).Each(func(i int, sel *goquery.Selection) {
-			title = extractQuestion(sel)
-		})
-		//fmt.Println(title)
-		question.Question.Content = title
+		// 题干（仅取题干节点）
+		question.Question.Content = extractWorkTitle(sel)
+
 		resOptions := make(map[string]string)
 		sel.Find(`div.centerSpan`).Each(func(i int, sel *goquery.Selection) {
-			//letter := strings.TrimSpace(sel.Find(`.No`).Text())
 			letter, _ := sel.Attr("id")
-			text := strings.TrimSpace(sel.Find(`p`).Text())
-			resOptions[letter] = letter + text
-			//fmt.Println(letter, text)
+			text := extractWorkOptionText(sel)
+			if letter == "" || text == "" {
+				return
+			}
+			resOptions[letter] = text
 		})
 		resSelect := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N"}
 		for _, slt := range resSelect {
-			if resOptions[slt] == "" {
+			v, ok := resOptions[slt]
+			if !ok || v == "" {
 				break
 			}
-			question.Question.Options = append(question.Question.Options, resOptions[slt])
+			question.Question.Options = append(question.Question.Options, v)
 		}
 	})
 

--- a/que-core/aiq/AiQuestion.go
+++ b/que-core/aiq/AiQuestion.go
@@ -899,6 +899,45 @@ func MetaAIReplyApi(model, apiKey string, aiChatMessages AIChatMessages, retryNu
 }
 
 // OtherChatReplyApi 其他支持CHATGPT API格式的AI模型接入
+// 尝试从模型返回中提取标准 JSON 数组（兼容 ```json 包裹、<think>...</think> 前置思考等）
+func normalizeJSONAnswerContent(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return s
+	}
+
+	// 去掉 markdown 代码块标记
+	s = strings.ReplaceAll(s, "```json", "")
+	s = strings.ReplaceAll(s, "```JSON", "")
+	s = strings.ReplaceAll(s, "```", "")
+	s = strings.TrimSpace(s)
+
+	// 去掉 <think>...</think>
+	for {
+		lower := strings.ToLower(s)
+		start := strings.Index(lower, "<think>")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(lower[start:], "</think>")
+		if end == -1 {
+			// 没闭合则直接裁掉 think 起始后的内容
+			s = strings.TrimSpace(s[:start])
+			break
+		}
+		end = start + end + len("</think>")
+		s = strings.TrimSpace(s[:start] + " " + s[end:])
+	}
+
+	// 提取首个 JSON 数组
+	l := strings.Index(s, "[")
+	r := strings.LastIndex(s, "]")
+	if l != -1 && r != -1 && r > l {
+		return strings.TrimSpace(s[l : r+1])
+	}
+	return strings.TrimSpace(s)
+}
+
 func OtherChatReplyApi(url,
 	model,
 	apiKey string,
@@ -918,10 +957,21 @@ func OtherChatReplyApi(url,
 		Transport: tr,
 		Timeout:   60 * time.Second, // Set connection and read timeout
 	}
+
+	// 兼容部分非 OpenAI 标准兼容接口（如 MiniMax chatcompletion_v2）
+	// 这类接口会拒绝 system role，这里退化为 user，避免直接 2013 invalid params。
+	normalizedMessages := make([]Message, 0, len(aiChatMessages.Messages))
+	for _, m := range aiChatMessages.Messages {
+		if strings.EqualFold(m.Role, "system") {
+			m.Role = "user"
+		}
+		normalizedMessages = append(normalizedMessages, m)
+	}
+
 	requestBody := map[string]interface{}{
 		"model":       model,
 		"temperature": 0.2,
-		"messages":    aiChatMessages.Messages,
+		"messages":    normalizedMessages,
 		//"response_format": map[string]string{"type": "json_object"},
 	}
 
@@ -976,8 +1026,9 @@ func OtherChatReplyApi(url,
 		return "", fmt.Errorf("content field missing or not a string in response")
 	}
 	//json格式检查逻辑-----------------------------------------
+	candidate := normalizeJSONAnswerContent(content)
 	var answers []string
-	err = json.Unmarshal([]byte(content), &answers)
+	err = json.Unmarshal([]byte(candidate), &answers)
 	if err != nil {
 		aiChatMessages.Messages = append(aiChatMessages.Messages, Message{
 			Role:    "system",
@@ -989,5 +1040,5 @@ func OtherChatReplyApi(url,
 		})
 		return OtherChatReplyApi(url, model, apiKey, aiChatMessages, retryNum-1, fmt.Errorf("生成的回复无法正常解析成json:%s", string(body)))
 	}
-	return content, nil
+	return candidate, nil
 }


### PR DESCRIPTION
## Summary
- Fix XueXiTong work parser to correctly extract doHomeWork question stem/options.
- Improve OTHER AI adapter compatibility for MiniMax chatcompletion_v2:
  - downgrade `system` role to `user` for non-OpenAI-compatible role constraints
  - normalize model output by stripping think/markdown wrappers and extracting JSON array payload.

## Why
- Previous parser produced polluted/empty options for doHomeWork pages.
- MiniMax responses could fail due to role validation and non-pure JSON wrappers.

## Files
- `aggregation/xuexitong/XuXiTongWorkAction.go`
- `que-core/aiq/AiQuestion.go`

## Validation
- Local run confirmed stable work answering flow with parsed full question/options.
- No `invalid message role: system` and no JSON parse failure in retried run.
