### PR TITLE
fix: 修复考试论述题类型判断

### DIFF
--- a/api/xuexitong/XueXiTongExamApi.go
+++ b/api/xuexitong/XueXiTongExamApi.go
@@ -613,7 +613,7 @@ func (cache *XueXiTUserCache) SubmitExamAnswerApi(question *XXTExamQuestionSubmi
 			blankNum += fmt.Sprintf("%d,", i+1)
 		}
 		values.Set("blankNum"+question.QuestionId, blankNum)
-	} else if question.QuestionTypeCode == "4" || question.QuestionTypeStr == "6" {
+	} else if question.QuestionTypeCode == "4" || question.QuestionTypeCode == "6" {
 		values.Set("type"+question.QuestionId, question.QuestionTypeCode)
 		values.Set("typeName"+question.QuestionId, question.QuestionTypeStr)
 		answerStr := ""


### PR DESCRIPTION
## Summary
- 修复考试提交答案时论述题类型判断错误的问题
- 将 `SubmitExamAnswerApi` 中论述题判断从 `QuestionTypeStr == "6"` 改为 `QuestionTypeCode == "6"`

## 背景
考试里的论述题不会自动作答，但作业里的论述题是正常的。原因是考试提交逻辑里用 `QuestionTypeStr` 去和数字编码 `"6"` 比较，而 `QuestionTypeStr` 存的是题型名称，不是题型编码，导致论述题分支没有命中。

## Test plan
- [x] 验证考试中的论述题可以正常进入答题提交逻辑
- [x] 验证作业中的论述题行为不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)