### PR TITLE
fix: 修复学习通链路请求安全问题

### DIFF
--- a/api/xuexitong/XueXiTongAIApi.go
+++ b/api/xuexitong/XueXiTongAIApi.go
@@ -89,9 +89,7 @@ func (cache *XueXiTUserCache) xxtAiInformApi(clazzId, courseId, cpi string, retr
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -171,9 +169,7 @@ func (cache *XueXiTUserCache) xxtAiAnswerApi(cozeEnc, userId, courseId, classId,
 		req.AddCookie(cookie)
 	}
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongAudioApi.go
+++ b/api/xuexitong/XueXiTongAudioApi.go
@@ -25,9 +25,7 @@ func (cache *XueXiTUserCache) AudioPhoneSubmitTimeApi(p *PointVideoDto, playingT
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongBBsApi.go
+++ b/api/xuexitong/XueXiTongBBsApi.go
@@ -27,9 +27,7 @@ func (cache *XueXiTUserCache) PullBbsCircleIdApi(mid, jobid string, isPortal boo
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -86,9 +84,7 @@ func (cache *XueXiTUserCache) PullUtEnc(courseId, clazzid, chapterId, enc string
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -151,9 +147,7 @@ func (cache *XueXiTUserCache) PullBbsInfoApi(id1, id2, courseId, classId string,
 	urlStr := "https://groupweb.chaoxing.com/course/topic/v3/bbs/" + id1 + "/" + id2 + "/replysList?courseId=" + courseId + "&classId=" + classId
 	method := "GET"
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -203,9 +197,7 @@ func (cache *XueXiTUserCache) PullPhoneBbsInfoApi(mtopid, jobid, knowledgeid, co
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -277,9 +269,7 @@ func (cache *XueXiTUserCache) PullPhoneBbsDetailApi(topicId string) (string, err
 	payload := strings.NewReader("puid=" + puid + "&maxW=1080&topicId=" + topicId)
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -335,9 +325,7 @@ func (cache *XueXiTUserCache) AnswerBbsApi(topicUUid, courseId, classId, topic_c
 	payload := strings.NewReader("courseId=" + courseId + "&classId=" + classId + "&replyId=-1&uuid=" + newUUID.String() + "&topic_content=" + url.QueryEscape(topic_content) + "&anonymous=&urlToken=" + urlToken + "&bbsid=" + bbsid)
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -407,9 +395,7 @@ func (cache *XueXiTUserCache) AnswerPhoneBbsApi(classId, topicUUID, content stri
 	payload := strings.NewReader("content=" + url.QueryEscape(content))
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {

--- a/api/xuexitong/XueXiTongCardApi.go
+++ b/api/xuexitong/XueXiTongCardApi.go
@@ -36,9 +36,7 @@ func (cache *XueXiTUserCache) PageMobileChapterCard(
 	//params.Add("pagestate", "0")
 	//params.Add("isMicroCourse", "false")
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -119,9 +117,7 @@ func (cache *XueXiTUserCache) VideoDtoFetch(p *PointVideoDto, retry int, lastErr
 	params.Set("_dc", strconv.FormatInt(time.Now().UnixNano()/1e6, 10))
 	method := "GET"
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -182,9 +178,7 @@ func (cache *XueXiTUserCache) VideoSubmitStudyTimeApi(p *PointVideoDto, playingT
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -265,9 +259,7 @@ func (cache *XueXiTUserCache) VideoSubmitStudyTimePEApi(p *PointVideoDto, playin
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -347,9 +339,7 @@ func (cache *XueXiTUserCache) VideoDtoPlayReport(p *PointVideoDto, playingTime i
 	enc := hex.EncodeToString(hash[:])
 	//fmt.Println(enc)
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -467,9 +457,7 @@ func (cache *XueXiTUserCache) WorkFetchQuestion(p *PointWorkDto, retry int, last
 	params.Add("ktoken", p.KToken)
 	params.Add("enc", p.Enc)
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -551,9 +539,7 @@ func (cache *XueXiTUserCache) WorkFetch1Question(p *PointWorkDto, retry int, las
 	params.Add("originJobId", p.JobID)
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -619,9 +605,7 @@ func (cache *XueXiTUserCache) WorkFetch2Question(p *PointWorkDto, retry int, las
 	params.Add("originJobId", p.JobID)
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -678,9 +662,7 @@ func (cache *XueXiTUserCache) WorkCommit(p *PointWorkDto, fields []WorkInputFiel
 	payload := strings.NewReader("")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -734,9 +716,7 @@ func (cache *XueXiTUserCache) DocumentDtoReadingReport(p *PointDocumentDto, retr
 	}
 	method := "GET"
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -798,9 +778,7 @@ func (cache *XueXiTUserCache) DocumentDtoReadingBookReport(p *PointDocumentDto, 
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -864,9 +842,7 @@ func (cache *XueXiTUserCache) ReadV2PointWebReport(p *PointDocumentDto, retry in
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -925,9 +901,7 @@ func (cache *XueXiTUserCache) ReadV2PointPeReport(p *PointDocumentDto, retry int
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -979,9 +953,7 @@ func (cache *XueXiTUserCache) HyperlinkDtoCompleteReport(p *PointHyperlinkDto, r
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -1035,9 +1007,7 @@ func (cache *XueXiTUserCache) PullLiveInfoApi(p *PointLiveDto, retry int, lastEr
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -1092,9 +1062,7 @@ func (cache *XueXiTUserCache) LiveRelationReport(p *PointLiveDto, retry int, las
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -1147,9 +1115,7 @@ func (cache *XueXiTUserCache) LiveWatchMomentReport(p *PointLiveDto, UParam stri
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -1201,9 +1167,7 @@ func (cache *XueXiTUserCache) LiveSaveTimePcReport(p *PointLiveDto, retry int, l
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {

--- a/api/xuexitong/XueXiTongChapterApi.go
+++ b/api/xuexitong/XueXiTongChapterApi.go
@@ -31,9 +31,7 @@ func (cache *XueXiTUserCache) PullChapter(cpi int, key int, retry int, lastErr e
 	params.Add("view", "json")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -104,9 +102,7 @@ func (cache *XueXiTUserCache) FetchChapterPointStatus(nodes []int, clazzID, user
 	payload := strings.NewReader(values.Encode())
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -170,9 +166,7 @@ func (cache *XueXiTUserCache) FetchChapterCords(nodes []int, index, courseId int
 	values.Add("_time", strconv.FormatInt(time.Now().UnixNano()/1000000, 10))
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -236,9 +230,7 @@ func (cache *XueXiTUserCache) FetchChapterCords2(clazzid, courseid, knowledgeid,
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -303,9 +295,7 @@ func (cache *XueXiTUserCache) EnterChapterForwardCallApi(courseId, clazzid, chap
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongChapterTestApi.go
+++ b/api/xuexitong/XueXiTongChapterTestApi.go
@@ -242,9 +242,7 @@ func (cache *XueXiTUserCache) WorkNewSubmitAnswer(courseId string, classId strin
 
 	// 发送请求
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongCourseApi.go
+++ b/api/xuexitong/XueXiTongCourseApi.go
@@ -22,9 +22,7 @@ func (cache *XueXiTUserCache) CourseListApi(retry int, lastErr error) (string, e
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -69,9 +67,7 @@ func (cache *XueXiTUserCache) CourseCompleteStatusApi(courseListData string, ret
 	//urlStr := "https://mooc2-ans.chaoxing.com/mooc2-ans/mycourse/stu-job-info?clazzPersonStr=134350229_407555221%252C125743273_407555221%252C127063689_407555221%252C126701067_407555221%252C125755386_407555221%252C125888882_407555221%252C125783661_454194591%252C124859308_454194591%252C124554421_454194591%252C116272688_407555221%252C117108284_407555221%252C117784832_407555221%252C116370785_407555221%252C116370660_407555221%252C117687599_407555221"
 	method := "GET"
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,

--- a/api/xuexitong/XueXiTongExamApi.go
+++ b/api/xuexitong/XueXiTongExamApi.go
@@ -62,9 +62,7 @@ func (cache *XueXiTUserCache) PullExamListHtmlApi(courseId string, classId strin
 	}
 	urlStr := "https://mooc1-api.chaoxing.com/mooc-ans/exam/phone/task-list?courseId=" + courseId + "&classId=" + classId + "&cpi=" + cpi
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -131,9 +129,7 @@ func (cache *XueXiTUserCache) PullExamEnterInformHtmlApi(
 	var finalURL string // ⭐ 用于保存最终的有效 URL
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -220,9 +216,7 @@ func (cache *XueXiTUserCache) PullExamPaperHtmlApi(courseId, classId, examId, so
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -272,9 +266,7 @@ func (cache *XueXiTUserCache) PullExamListHtmlTwoApi(urlStr string, retry int, l
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -320,9 +312,7 @@ func (cache *XueXiTUserCache) PullReDoExamPaperHtmlApi(urlStr string, retry int,
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -373,9 +363,7 @@ func (cache *XueXiTUserCache) StartReExamApi(examId, examAnswerId, courseId, cla
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -437,9 +425,7 @@ func (cache *XueXiTUserCache) PullReExamPaperHtmlApi(urlStr string) (string, err
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -487,9 +473,7 @@ func (cache *XueXiTUserCache) PullExamQuestionApi(courseId, classId, tId, id, cp
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -626,9 +610,7 @@ func (cache *XueXiTUserCache) SubmitExamAnswerApi(question *XXTExamQuestionSubmi
 	payload := strings.NewReader(values.Encode())
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongFaceApi.go
+++ b/api/xuexitong/XueXiTongFaceApi.go
@@ -32,9 +32,7 @@ func (cache *XueXiTUserCache) GetFaceUpLoadToken() (string, error) {
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -96,9 +94,7 @@ func (cache *XueXiTUserCache) GetHistoryFaceImg(puid string) (string, image.Imag
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -212,9 +208,7 @@ func (cache *XueXiTUserCache) UploadFaceImageApi(token string, image image.Image
 	writer.Close()
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -290,9 +284,7 @@ func (cache *XueXiTUserCache) GetFaceQrCodeApi1(courseId, clazzid, chapterId, cp
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -355,9 +347,7 @@ func (cache *XueXiTUserCache) GetFaceQrCodeApi2(courseId, clazzId, cpi string) (
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -426,9 +416,7 @@ func (cache *XueXiTUserCache) GetFaceQrCodeApi3(courseId, clazzid, chapterId, cp
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -497,9 +485,7 @@ func (cache *XueXiTUserCache) GetFaceQrCodeApi3(courseId, clazzid, chapterId, cp
 	method1 := "GET"
 
 	tr1 := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -565,9 +551,7 @@ func (cache *XueXiTUserCache) GetCourseFaceQrPlan1Api(courseId, classId, uuid, o
 	payload := strings.NewReader("clazzId=" + classId + "&courseId=" + courseId + "&uuid=" + uuid + "&qrcEnc=" + qrcEnc + "&objectId=" + objectId + "&failCount=" + failCount + "&compareResult=0")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -618,9 +602,7 @@ func (cache *XueXiTUserCache) PassFaceQrPlanPhoneNewApi(classId, courseId, knowl
 	urlStr := "https://mooc1-api.chaoxing.com/mooc-ans/facephoto/clientfacecheckstatus?" + "courseId=" + courseId + "&clazzId=" + classId + "&cpi=" + cpi + "&chapterId=" + knowledgeId + "&objectId=" + objectId + "&liveDetectionStatus=1" + "&signt=" + "&signk=" + "&cxtime=" + "&cxcid=" + "&type=1"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -682,9 +664,7 @@ func (cache *XueXiTUserCache) PassFaceQrPlanPhoneNew2Api(classId, courseId, know
 	form.Set("type", "0")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -741,9 +721,7 @@ func (cache *XueXiTUserCache) PassFaceQrPlanPhoneOldApi(classId, courseId, knowl
 	//payload := strings.NewReader("clazzId=130390181&courseId=256426381&knowledgeId=705058652&uuid=&qrcEnc=&objectId=123")
 	payload := strings.NewReader("clazzId=" + classId + "&courseId=" + courseId + "&knowledgeId=" + knowledgeId + "&uuid=&qrcEnc=&objectId=" + objectId)
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -819,9 +797,7 @@ func (cache *XueXiTUserCache) GetCourseFaceQrPlan5Api(classId, courseId, knowled
 	form.Set("type", "1")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -874,9 +850,7 @@ func (cache *XueXiTUserCache) GetCourseFaceQrPlan3Api(clazzId, courseId, uuid, q
 	payload := strings.NewReader("clazzId=" + clazzId + "&courseId=" + courseId + "&uuid=" + uuid + "&qrcEnc=" + qrcEnc + "&cpi=" + cpi + "&liveDetectionStatus=0&signt=&signk=&cxtime=&cxcid=&knowledgeid=0" + "&objectId=" + objectId + "&videojobid=&videoCollectTime=0&chaptervideoobjectid=")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -924,9 +898,7 @@ func (cache *XueXiTUserCache) GetCourseFaceStart(clazzId, courseId, knowledgeId,
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -974,9 +946,7 @@ func (cache *XueXiTUserCache) ContinueStudy(clazzId, courseId, cpi, objectId, er
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -1027,9 +997,7 @@ func (cache *XueXiTUserCache) GetCourseFaceQrPlan4Api(clazzId, courseId, knowled
 	payload := strings.NewReader("clazzId=" + clazzId + "&courseId=" + courseId + "&knowledgeId=" + knowledgeId + "&uuid=" + uuid + "&qrcEnc=" + qrcEnc + "&objectId=" + objectId)
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -1069,9 +1037,7 @@ func (cache *XueXiTUserCache) GetCourseFaceQrStateApi(uuid, enc, clazzid, course
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongLoginApi.go
+++ b/api/xuexitong/XueXiTongLoginApi.go
@@ -135,9 +135,7 @@ func (cache *XueXiTUserCache) LoginApi(retry int) (string, error) {
 	passwdEncrypted := base64.StdEncoding.EncodeToString(passwdCipherText)
 	//设置代理
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -215,9 +213,7 @@ func (cache *XueXiTUserCache) MonitorApi() (string, error) {
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongReadApi.go
+++ b/api/xuexitong/XueXiTongReadApi.go
@@ -40,9 +40,7 @@ func (cache *XueXiTUserCache) ReadSubmitTimeLog(p *PointDocumentDto, retry int, 
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/XueXiTongVerCodeApi.go
+++ b/api/xuexitong/XueXiTongVerCodeApi.go
@@ -31,9 +31,7 @@ func (cache *XueXiTUserCache) XueXiTVerificationCodeApi(retry int, lastErr error
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -85,9 +83,7 @@ func (cache *XueXiTUserCache) XueXiTChapterVerificationCodeApi(retry int, lastEr
 		fmt.Sprintf("%d", time.Now().UnixMilli())
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	// 代理
@@ -149,9 +145,7 @@ func (cache *XueXiTUserCache) XueXiTPassVerificationCode(code string, retry int,
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -222,9 +216,7 @@ func (cache *XueXiTUserCache) XueXiTPassCahpterVerificationCode(code string, ret
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	//如果开启了IP代理，那么就直接添加代理
 	if cache.IpProxySW {
@@ -282,9 +274,7 @@ func (cache *XueXiTUserCache) XueXiTSliderVerificationCodeApi(captchaId string, 
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -347,9 +337,7 @@ func (cache *XueXiTUserCache) XueXiTSliderVerificationImgApi(captchaId, serverTi
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -401,12 +389,13 @@ func (cache *XueXiTUserCache) PullSliderImgApi(imgUrl string, retry int, lastErr
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return fmt.Errorf("滑块图片请求不允许重定向")
+		},
 	}
 	req, err := http.NewRequest(method, imgUrl, nil)
 
@@ -417,9 +406,6 @@ func (cache *XueXiTUserCache) PullSliderImgApi(imgUrl string, retry int, lastErr
 	req.Header.Add("User-Agent", GetUA("mobile"))
 	req.Header.Add("Accept-Language", "zh-CN,en-US;q=0.9")
 	req.Header.Add("X-Requested-With", "com.chaoxing.mobile")
-	for _, cookie := range cache.cookies {
-		req.AddCookie(cookie)
-	}
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "captcha.chaoxing.com")
 	req.Header.Add("Connection", "keep-alive")
@@ -451,9 +437,7 @@ func (cache *XueXiTUserCache) PassSliderApi(captchaId, token, xPoint, runEnv str
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,

--- a/api/xuexitong/XueXiTongWorkApi.go
+++ b/api/xuexitong/XueXiTongWorkApi.go
@@ -69,9 +69,7 @@ func (cache *XueXiTUserCache) PullWorkListHtmlApi(courseId string, classId strin
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -139,9 +137,7 @@ func (cache *XueXiTUserCache) PullWorkEnterInformHtmlApi(
 	var finalURL string // ⭐ 用于保存最终的有效 URL
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 	client := &http.Client{
 		Transport: tr,
@@ -213,9 +209,7 @@ func (cache *XueXiTUserCache) PullWorkPaperHtmlApi(courseId, classId, workId, so
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -352,9 +346,7 @@ func (cache *XueXiTUserCache) SubmitWorkAnswerApi(question *XXTWorkQuestionSubmi
 	//payload := strings.NewReader("workExamUploadUrl=&workExamUploadCrcUrl=&workRelationAnswerId=54657628&knowledgeid=0&enc=737ad94cd5529ffa3ba68606eb91a124&source=0&encWork=ace56cb8a1c65f68339d3cd452757caa&courseId=258101827&workRelationId=48731428&classId=134204187&workTimesEnc=&courseId=258101827&workRelationId=48731428&classId=134204187&answer405139692=A&type405139692=0&score405139692=100.0&questionId=405139692&index=0&tempSave=false")
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理
@@ -408,9 +400,7 @@ func (cache *XueXiTUserCache) PullWorkQuestionApi(courseId, classId, workId, sou
 	method := "GET"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // 跳过证书验证，仅用于开发环境
-		},
+		TLSClientConfig: &tls.Config{},
 	}
 
 	//如果开启了IP代理，那么就直接添加代理

--- a/api/xuexitong/security_transport_test.go
+++ b/api/xuexitong/security_transport_test.go
@@ -1,0 +1,108 @@
+package xuexitong
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestXueXiTongTLSVerificationEnabled(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fset := token.NewFileSet()
+	for _, filename := range files {
+		file, err := parser.ParseFile(fset, filename, nil, 0)
+		if err != nil {
+			t.Fatalf("解析 %s 失败: %v", filename, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			literal, ok := node.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			selector, ok := literal.Type.(*ast.SelectorExpr)
+			if !ok || selector.Sel.Name != "Config" {
+				return true
+			}
+			ident, ok := selector.X.(*ast.Ident)
+			if !ok || ident.Name != "tls" {
+				return true
+			}
+			for _, element := range literal.Elts {
+				field, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				name, ok := field.Key.(*ast.Ident)
+				if !ok || name.Name != "InsecureSkipVerify" {
+					continue
+				}
+				value, ok := field.Value.(*ast.Ident)
+				if ok && value.Name == "true" {
+					t.Errorf("%s 禁用了 TLS 证书校验", filename)
+				}
+			}
+			return true
+		})
+	}
+}
+
+func TestPullSliderImgApiDoesNotForwardCookies(t *testing.T) {
+	pngBody := newTestPNG(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Cookie"); got != "" {
+			t.Errorf("滑块图片请求转发了 Cookie: %q", got)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngBody)
+	}))
+	defer server.Close()
+
+	cache := &XueXiTUserCache{}
+	cache.SetCookies([]*http.Cookie{{Name: "session", Value: "sensitive"}})
+	if _, err := cache.PullSliderImgApi(server.URL, 0, nil); err != nil {
+		t.Fatalf("拉取未重定向的图片失败: %v", err)
+	}
+}
+
+func TestPullSliderImgApiRejectsRedirects(t *testing.T) {
+	redirectTargetHits := 0
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		redirectTargetHits++
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer source.Close()
+
+	if _, err := (&XueXiTUserCache{}).PullSliderImgApi(source.URL, 0, nil); err == nil {
+		t.Fatal("滑块图片请求接受了重定向")
+	}
+	if redirectTargetHits != 0 {
+		t.Fatalf("滑块图片请求跟随了重定向，目标收到 %d 次请求", redirectTargetHits)
+	}
+}
+
+func newTestPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.White)
+	var body bytes.Buffer
+	if err := png.Encode(&body, img); err != nil {
+		t.Fatal(err)
+	}
+	return body.Bytes()
+}


### PR DESCRIPTION
## 目的

### 1. 此前学习通接口没有 TLS 证书校验

网络被劫持或证书异常时，客户端仍会继续把账号密码、登录 Cookie 和学习数据发给伪造服务——正常编译后，生产请求会无条件走 `InsecureSkipVerify: true`

> [!WARNING]
> 客户端在完全没有身份验证的情况下就会把**账号密码、Cookie 和学习数据**发出去，中间人攻击、网络劫持、伪造服务端都能轻易拿到这些敏感信息。

### 2. 滑块图片请求会把当前账号 Cookie 发给学习通返回的图片地址，并自动跟随跳转

图片地址若被替换或跳到非预期域名，账号会话可能泄露

> [!WARNING]
>
> 滑块图片请求会无条件携带当前会话 Cookie 并自动跟随任何重定向，如果返回的图片地址被篡改或者指向了恶意域名，账号会话就会被直接泄露出去

## 改动

- 修复学习通请求在生产路径中无条件跳过 TLS 证书校验的问题
- 滑块图片不再携带账号 Cookie，拒绝自动跳转