### PR TITLE
fix: 修复学习通请求失败与任务点解析崩溃

### DIFF
--- a/aggregation/xuexitong/XuXiTongWorkAction.go
+++ b/aggregation/xuexitong/XuXiTongWorkAction.go
@@ -58,7 +58,7 @@ func PullWorkListAction(cache *xuexitong.XueXiTUserCache, course XueXiTCourse) (
 	}
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(examListHtml))
 	if err != nil {
-		log.Fatal(err)
+		return examList, fmt.Errorf("解析作业列表失败: %w", err)
 	}
 
 	// 遍历所有 <li>
@@ -135,7 +135,7 @@ func EnterWorkAction(cache *xuexitong.XueXiTUserCache, exam *XXTWork) error {
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(enterHtml))
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("解析作业入口失败: %w", err)
 	}
 	type HiddenField struct {
 		ID    string
@@ -307,7 +307,7 @@ func (question *XXTWorkQuestion) WriteQuestionForXXTAIAction(cache *xuexitong.Xu
 	aiAnswer, err := cache.XueXiTongAIAggregation(classId, courseId, cpi, aiChatMessages)
 
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("学习通 AI 答题失败: %w", err)
 	}
 	var answers []string
 	err = json.Unmarshal([]byte(aiAnswer), &answers)
@@ -338,7 +338,7 @@ func HtmlWorkQuestionTurnEntity(paperHtml string) (XXTWorkQuestion, error) {
 	// 使用 goquery 解析 HTML
 	paperDoc, err := goquery.NewDocumentFromReader(bytes.NewReader([]byte(paperHtml)))
 	if err != nil {
-		log.Fatal(err)
+		return question, fmt.Errorf("解析作业题目失败: %w", err)
 	}
 	questionId, exists := paperDoc.Find("#questionId").Attr("value") //题目id
 	if exists {

--- a/aggregation/xuexitong/XuXiTongWorkAction.go
+++ b/aggregation/xuexitong/XuXiTongWorkAction.go
@@ -2,6 +2,7 @@ package xuexitong
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -178,16 +179,11 @@ func EnterWorkAction(cache *xuexitong.XueXiTUserCache, exam *XXTWork) error {
 			CaptchaId: exam.CaptchaCaptchaId,
 			Referer:   refererUrl,
 		}
-		for {
-			validate, passErr := slider.Pass(cache)
-			if passErr != nil {
-				if strings.Contains(passErr.Error(), `"result":false`) {
-					continue
-				}
-			}
-			exam.Validate = validate
-			break //如果成功了那么直接退出循环
+		validate, passErr := passSliderCaptcha(context.Background(), cache, &slider)
+		if passErr != nil {
+			return fmt.Errorf("作业滑块验证码处理失败: %w", passErr)
 		}
+		exam.Validate = validate
 	}
 	cpi, answerId, enc := extractParams(enterHtml)
 	exam.Cpi = cpi

--- a/aggregation/xuexitong/XueXiTongCardAction.go
+++ b/aggregation/xuexitong/XueXiTongCardAction.go
@@ -2,6 +2,7 @@ package xuexitong
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,10 +12,8 @@ import (
 	"strings"
 	"time"
 
-	ddddocr "github.com/Changbaiqi/ddddocr-go/utils"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/thedevsaddam/gojsonq"
-	ort "github.com/yalue/onnxruntime_go"
 	"github.com/yatori-dev/yatori-go-core/api/xuexitong"
 	que_core "github.com/yatori-dev/yatori-go-core/que-core/aiq"
 	"github.com/yatori-dev/yatori-go-core/que-core/qtype"
@@ -47,27 +46,8 @@ func PageMobileChapterCardAction(
 	if err != nil {
 		if err.Error() == "触发验证码" {
 			log2.Print(log2.DEBUG, utils.RunFuncName(), "触发验证码，正在进行AI智能识别绕过.....")
-			for {
-				img, err1 := cache.XueXiTVerificationCodeApi(7, nil)
-				if err1 != nil {
-					return nil, "", err1
-				}
-				//codeResult := utils.AutoVerification(img, ort.NewShape(1, 23)) //自动识别
-				_, width, _ := utils.GetImageShape(img)
-
-				var shape ort.Shape
-				if width == 140 {
-					shape = ort.NewShape(1, 23)
-				} else {
-					shape = ort.NewShape(1, 30)
-				}
-				codeResult := ddddocr.SemiOCRVerification(img, shape)
-				status, err1 := cache.XueXiTPassVerificationCode(codeResult, 7, nil)
-				//fmt.Println(codeResult)
-				//fmt.Println(status)
-				if status {
-					break
-				}
+			if err := passImageCaptcha(context.Background(), cache); err != nil {
+				return nil, "", fmt.Errorf("章节卡片验证码处理失败: %w", err)
 			}
 			cardHtml, err = cache.PageMobileChapterCard(classId, courseId, knowledgeId, cardIndex, cpi, 3, nil) //尝试重新拉取卡片信息
 			log2.Print(log2.DEBUG, utils.RunFuncName(), "绕过成功")

--- a/aggregation/xuexitong/XueXiTongCardAction.go
+++ b/aggregation/xuexitong/XueXiTongCardAction.go
@@ -73,9 +73,12 @@ func PageMobileChapterCardAction(
 			log2.Print(log2.DEBUG, utils.RunFuncName(), "绕过成功")
 		}
 	}
+	if err != nil {
+		return nil, "", fmt.Errorf("拉取章节卡片失败: %w", err)
+	}
 
 	if strings.Contains(cardHtml, `<p class="blankTips">章节未开放</p>`) {
-		return nil, "", errors.New("章节未开放")
+		return nil, "", ChapterNotOpened{}
 	}
 	//如果遇到人脸,则进行过人脸
 	if strings.Contains(cardHtml, `title : "人脸识别"`) {
@@ -95,11 +98,17 @@ func PageMobileChapterCardAction(
 		}
 		//过完人脸重新拉取章节信息
 		cardHtml, err = cache.PageMobileChapterCard(classId, courseId, knowledgeId, cardIndex, cpi, 3, nil)
+		if err != nil {
+			return nil, "", fmt.Errorf("人脸识别后拉取章节卡片失败: %w", err)
+		}
 		//如果新版本人脸过不去，则再尝试旧版本人脸
 		if strings.Contains(cardHtml, `title : "人脸识别"`) {
 			ObjectId, err1 = PassFacePhoneOldAction(cache, fmt.Sprintf("%d", courseId), fmt.Sprintf("%d", classId), fmt.Sprintf("%d", cpi), fmt.Sprintf("%d", knowledgeId), "", "", "")
 			time.Sleep(1 * time.Second) //隔一下
 			cardHtml, err = cache.PageMobileChapterCard(classId, courseId, knowledgeId, cardIndex, cpi, 3, nil)
+			if err != nil {
+				return nil, "", fmt.Errorf("旧版人脸识别后拉取章节卡片失败: %w", err)
+			}
 		}
 
 		if strings.Contains(cardHtml, `title : "人脸识别"`) {
@@ -125,61 +134,49 @@ func PageMobileChapterCardAction(
 			}
 		}
 	}
-	var att interface{}
 
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to fetch pageMobileChapterCard: %w", err)
-	}
+	return parseAttachmentSetting(cardHtml)
+}
+
+func parseAttachmentSetting(cardHtml string) (map[string]interface{}, string, error) {
 	doc, err := html.Parse(bytes.NewReader([]byte(cardHtml)))
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to parse HTML: %w", err)
+		return nil, "", fmt.Errorf("解析章节卡片 HTML 失败: %w", err)
 	}
-
-	var scriptContent string
-	var traverse func(*html.Node)
-	traverse = func(n *html.Node) {
-		if n.Type == html.ElementNode && n.Data == "script" {
-			// Check if the script tag has a type attribute and its value is "text/javascript"
-			hasTypeAttr := false
-			for _, attr := range n.Attr {
-				if attr.Key == "type" && strings.TrimSpace(attr.Val) == "text/javascript" {
-					hasTypeAttr = true
-					break
-				}
-			}
-
-			if hasTypeAttr {
-				// Check if the script tag has a child node and it's a text node
-				if n.FirstChild != nil && n.FirstChild.Type == html.TextNode {
-					scriptContent = strings.TrimSpace(n.FirstChild.Data)
-					return // Exit the traversal as we found what we need
-				}
-			}
-		}
-
-		// Continue traversing the children nodes
-		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			traverse(c)
-		}
-	}
-	traverse(doc)
 
 	// Define the regex pattern to match window.AttachmentSetting JSON object
-	re := regexp.MustCompile(`window\.AttachmentSetting\s*=\s*(\{.*?\});`)
-	matches := re.FindStringSubmatch(scriptContent)
+	re := regexp.MustCompile(`(?s)window\.AttachmentSetting\s*=\s*(\{.*?\});`)
+	matches := re.FindStringSubmatch(cardHtml)
 	if len(matches) > 1 {
-		var attachment interface{}
+		var attachment map[string]interface{}
 		if err := json.Unmarshal([]byte(matches[1]), &attachment); err != nil {
-			return nil, "", fmt.Errorf("failed to parse JSON: %w", err)
+			return nil, "", fmt.Errorf("解析 AttachmentSetting 失败: %w", err)
 		}
-		att = attachment
+		if attachment == nil {
+			return nil, "", APIError{Message: "AttachmentSetting 不是对象"}
+		}
+
+		reEnc := regexp.MustCompile(`<input type="hidden" id="from" value="[^_]+_[^_]+_[^_]+_([^"]+)"/>`)
+		matchesEnc := reEnc.FindStringSubmatch(cardHtml)
+		enc := ""
+		if len(matchesEnc) > 1 {
+			enc = matchesEnc[1]
+			attachment["enc"] = enc
+		}
+		return attachment, enc, nil
 	} else {
 		var blankTips string
+		var traverse func(*html.Node)
 		traverse = func(n *html.Node) {
 			if n.Type == html.ElementNode && n.Data == "p" {
 				for _, attr := range n.Attr {
 					if attr.Key == "class" && strings.Contains(attr.Val, "blankTips") {
-						blankTips = strings.TrimSpace(n.FirstChild.Data)
+						for child := n.FirstChild; child != nil; child = child.NextSibling {
+							if child.Type == html.TextNode {
+								blankTips += child.Data
+							}
+						}
+						blankTips = strings.TrimSpace(blankTips)
 						return
 					}
 				}
@@ -190,22 +187,14 @@ func PageMobileChapterCardAction(
 		}
 		traverse(doc)
 
-		if strings.TrimSpace(blankTips) == "章节未开放！" {
-			log.Println("章节未开放")
-			return ChapterNotOpened{}, "", nil
+		if strings.TrimRight(strings.TrimSpace(blankTips), "！!") == "章节未开放" {
+			return nil, "", ChapterNotOpened{}
 		}
-		return APIError{Message: blankTips}, "", nil
+		if blankTips == "" {
+			blankTips = "章节卡片缺少 AttachmentSetting"
+		}
+		return nil, "", APIError{Message: blankTips}
 	}
-	// 截取
-	reEnc := regexp.MustCompile(`<input type="hidden" id="from" value="[^_]+_[^_]+_[^_]+_([^"]+)"/>`)
-	matchesEnc := reEnc.FindStringSubmatch(cardHtml)
-	enc := ""
-	if len(matchesEnc) > 1 {
-		enc = matchesEnc[1]
-		(att.(map[string]interface{}))["enc"] = enc
-	}
-	//log.Println("Attachment拉取成功")
-	return att, enc, nil
 }
 
 func VideoDtoFetchAction(cache *xuexitong.XueXiTUserCache, p *xuexitong.PointVideoDto) (bool, error) {
@@ -386,7 +375,7 @@ func ParseWorkQuestionAction(cache *xuexitong.XueXiTUserCache, workPoint *xuexit
 	// 使用 goquery 解析 HTML
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader([]byte(question)))
 	if err != nil {
-		log.Fatal(err)
+		return questionEntity, fmt.Errorf("解析作业页面失败: %w", err)
 	}
 
 	//用于拉取并完善workPointDto信息
@@ -416,7 +405,7 @@ func ParseWorkQuestionAction(cache *xuexitong.XueXiTUserCache, workPoint *xuexit
 	for _, qs := range questionSets {
 		qdoc, err := goquery.NewDocumentFromReader(bytes.NewReader([]byte(qs.HTML)))
 		if err != nil {
-			log.Fatal(err)
+			return questionEntity, fmt.Errorf("解析作业题目失败: %w", err)
 		}
 
 		// 提取题目类型和题目文本

--- a/aggregation/xuexitong/XueXiTongCardAction_test.go
+++ b/aggregation/xuexitong/XueXiTongCardAction_test.go
@@ -1,0 +1,33 @@
+package xuexitong
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseAttachmentSettingReturnsBusinessError(t *testing.T) {
+	_, _, err := parseAttachmentSetting(`<html><body><p class="blankTips">任务点暂不可用</p></body></html>`)
+	var apiErr APIError
+	if !errors.As(err, &apiErr) || apiErr.Message != "任务点暂不可用" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAttachmentSettingReturnsChapterNotOpened(t *testing.T) {
+	_, _, err := parseAttachmentSetting(`<html><body><p class="blankTips">章节未开放！</p></body></html>`)
+	var blocked ChapterNotOpened
+	if !errors.As(err, &blocked) {
+		t.Fatalf("expected ChapterNotOpened, got %v", err)
+	}
+}
+
+func TestParseAttachmentSettingReturnsObjectAndEnc(t *testing.T) {
+	html := `<html><body><script type="text/javascript">window.AttachmentSetting = {"attachments":[],"defaults":{"fid":"1"}};</script><input type="hidden" id="from" value="a_b_c_enc-value"/></body></html>`
+	attachment, enc, err := parseAttachmentSetting(html)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enc != "enc-value" || attachment["enc"] != enc {
+		t.Fatalf("unexpected enc: %q, attachment: %#v", enc, attachment)
+	}
+}

--- a/aggregation/xuexitong/XueXiTongChapterAction.go
+++ b/aggregation/xuexitong/XueXiTongChapterAction.go
@@ -2,6 +2,7 @@ package xuexitong
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -9,9 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	ddddocr "github.com/Changbaiqi/ddddocr-go/utils"
 	"github.com/thedevsaddam/gojsonq"
-	ort "github.com/yalue/onnxruntime_go"
 
 	"github.com/yatori-dev/yatori-go-core/api/xuexitong"
 	"github.com/yatori-dev/yatori-go-core/models/ctype"
@@ -77,27 +76,8 @@ func ChapterFetchCardsAction(
 			log2.Print(log2.DEBUG, "重新登录后cords值>>", fmt.Sprintf("%+v", cords))
 		} else if err.Error() == "触发验证码" {
 			log2.Print(log2.DEBUG, utils.RunFuncName(), "触发验证码，正在进行AI智能识别绕过.....")
-			for {
-				img, err1 := cache.XueXiTVerificationCodeApi(7, nil)
-				if err1 != nil {
-					return nil, nil, err1
-				}
-
-				_, width, _ := utils.GetImageShape(img)
-
-				var shape ort.Shape
-				if width == 140 {
-					shape = ort.NewShape(1, 23)
-				} else {
-					shape = ort.NewShape(1, 30)
-				}
-				codeResult := ddddocr.SemiOCRVerification(img, shape)
-				status, err1 := cache.XueXiTPassVerificationCode(codeResult, 7, nil)
-				//fmt.Println(codeResult)
-				//fmt.Println(status)
-				if status {
-					break
-				}
+			if err := passImageCaptcha(context.Background(), cache); err != nil {
+				return nil, nil, fmt.Errorf("章节卡片验证码处理失败: %w", err)
 			}
 			cords, err = cache.FetchChapterCords(nodes, index, courseId, 5, nil) //尝试重新拉取卡片信息
 			log2.Print(log2.DEBUG, utils.RunFuncName(), "绕过成功")
@@ -621,24 +601,8 @@ func EnterChapterForwardCallAction(cache *xuexitong.XueXiTUserCache, courseId, c
 			}
 		} else if err.Error() == "触发验证码" {
 			log2.Print(log2.DEBUG, utils.RunFuncName(), "触发验证码，正在进行AI智能识别绕过.....")
-			for {
-				img, err1 := cache.XueXiTVerificationCodeApi(7, nil)
-				if err1 != nil {
-					return err1
-				}
-				_, width, _ := utils.GetImageShape(img)
-
-				var shape ort.Shape
-				if width == 140 {
-					shape = ort.NewShape(1, 23)
-				} else {
-					shape = ort.NewShape(1, 30)
-				}
-				codeResult := ddddocr.SemiOCRVerification(img, shape)
-				status, err1 := cache.XueXiTPassVerificationCode(codeResult, 7, nil)
-				if status {
-					break
-				}
+			if err := passImageCaptcha(context.Background(), cache); err != nil {
+				return fmt.Errorf("进入章节验证码处理失败: %w", err)
 			}
 			err = cache.EnterChapterForwardCallApi(courseId, clazzid, chapterId, cpi, 3, nil) //尝试重新拉取卡片信息
 			log2.Print(log2.DEBUG, utils.RunFuncName(), "绕过成功")

--- a/aggregation/xuexitong/XueXiTongCourseAction.go
+++ b/aggregation/xuexitong/XueXiTongCourseAction.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -217,80 +216,65 @@ func PullCourseChapterActionContext(ctx context.Context, cache *xuexitong.XueXiT
 		return ChaptersList{}, false, errors.New("[" + cache.Name + "] " + " 拉取章节失败" + err.Error())
 	}
 
-	var chapterMap map[string]interface{}
-	err = json.Unmarshal([]byte(chapter), &chapterMap)
-	if err != nil {
-		return ChaptersList{}, false, errors.New(fmt.Sprintf("Error parsing JSON: %s", err))
+	type chapterKnowledge struct {
+		JobCount   int    `json:"jobcount"`
+		IsReview   int    `json:"isreview"`
+		IndexOrder int    `json:"indexorder"`
+		Name       string `json:"name"`
+		ID         int    `json:"id"`
+		Label      string `json:"label"`
+		Layer      int    `json:"layer"`
+		ParentNode int    `json:"parentnodeid"`
+		Status     string `json:"status"`
+		Attachment struct {
+			Data []interface{} `json:"data"`
+		} `json:"attachment"`
 	}
-	chapterMapJson, err := json.Marshal(chapterMap["data"])
-	if len(chapterMapJson) == 2 {
-		return ChaptersList{}, false, errors.New("[" + cache.Name + "] " + "[" + chaptersList.ChatID + "] " + " 课程获取失败" + chapter)
+	var response struct {
+		Data []struct {
+			ChatID  string `json:"chatid"`
+			IsStart bool   `json:"isstart"`
+			BbsID   string `json:"bbsid"`
+			Course  struct {
+				Data []struct {
+					Knowledge struct {
+						Data []chapterKnowledge `json:"data"`
+					} `json:"knowledge"`
+				} `json:"data"`
+			} `json:"course"`
+		} `json:"data"`
 	}
-	// 解析 JSON 数据为 map 切片
-	var chapterData []map[string]interface{}
-	if err := json.Unmarshal(chapterMapJson, &chapterData); err != nil {
-		log.Fatalf("Error parsing JSON: %v", err)
+	if err := json.Unmarshal([]byte(chapter), &response); err != nil {
+		return ChaptersList{}, false, fmt.Errorf("[%s] 解析课程章节失败: %w", cache.Name, err)
 	}
-	var chatid string
-	if v, ok1 := chapterData[0]["chatid"].(string); ok1 {
-		chatid = v
+	if len(response.Data) == 0 {
+		return ChaptersList{}, false, fmt.Errorf("[%s] 课程章节响应缺少 data", cache.Name)
 	}
-	var isstart bool
-	if v, ok2 := chapterData[0]["isstart"].(bool); ok2 {
-		isstart = v
-	}
-	var bbsid string
-	if v, ok3 := chapterData[0]["bbsid"].(string); ok3 {
-		bbsid = v
-	}
-	//else {//chatid并不是非必要项，所以所以注释掉了
-	//	return ChaptersList{}, false, errors.New("[" + cache.Name + "] " + "[" + chaptersList.ChatID + "] " + " 课程获取失败" + chapter)
-	//}
-
-	// 提取 knowledge
-	var knowledgeData []map[string]interface{}
-	course, ok := chapterData[0]["course"].(map[string]interface{})
-	if !ok {
-		return ChaptersList{}, ok, errors.New("[" + cache.Name + "] " + "[" + chaptersList.ChatID + "] " + " 无法提取 course")
-	}
-	data, ok := course["data"].([]interface{})
-	if !ok {
-		return ChaptersList{}, ok, errors.New("[" + cache.Name + "] " + "[" + chaptersList.ChatID + "] " + " 无法提取 course data")
-	}
-	if len(data) > 0 {
-		knowledge, ok := data[0].(map[string]interface{})["knowledge"].(map[string]interface{})["data"].([]interface{})
-		if !ok {
-			return ChaptersList{}, ok, errors.New("[" + cache.Name + "] " + "[" + chaptersList.ChatID + "] " + " 无法提取 knowledge data")
-		}
-		for _, item := range knowledge {
-			knowledgeMap := item.(map[string]interface{})
-			knowledgeData = append(knowledgeData, knowledgeMap)
-		}
-	} else {
-		return ChaptersList{}, false, errors.New("[" + cache.Name + "] " + "[" + chaptersList.ChatID + "] " + " course data 为空")
+	chapterData := response.Data[0]
+	if len(chapterData.Course.Data) == 0 {
+		return ChaptersList{}, false, fmt.Errorf("[%s] 课程章节响应缺少 course.data", cache.Name)
 	}
 
-	// 将提取的数据封装到 CourseInfo 结构体中
-	var knowledgeItems []KnowledgeItem
+	knowledgeData := chapterData.Course.Data[0].Knowledge.Data
+	knowledgeItems := make([]KnowledgeItem, 0, len(knowledgeData))
 	for _, item := range knowledgeData {
-		knowledgeItem := KnowledgeItem{
-			JobCount:     int(item["jobcount"].(float64)),
-			IsReview:     int(item["isreview"].(float64)),
-			Attachment:   item["attachment"].(map[string]interface{})["data"].([]interface{}),
-			IndexOrder:   int(item["indexorder"].(float64)),
-			Name:         item["name"].(string),
-			ID:           int(item["id"].(float64)),
-			Label:        item["label"].(string),
-			Layer:        int(item["layer"].(float64)),
-			ParentNodeID: int(item["parentnodeid"].(float64)),
-			Status:       item["status"].(string),
-		}
-		knowledgeItems = append(knowledgeItems, knowledgeItem)
+		knowledgeItems = append(knowledgeItems, KnowledgeItem{
+			JobCount:     item.JobCount,
+			IsReview:     item.IsReview,
+			Attachment:   item.Attachment.Data,
+			IndexOrder:   item.IndexOrder,
+			Name:         item.Name,
+			ID:           item.ID,
+			Label:        item.Label,
+			Layer:        item.Layer,
+			ParentNodeID: item.ParentNode,
+			Status:       item.Status,
+		})
 	}
 	chaptersList = ChaptersList{
-		ChatID:    chatid,
-		IsStart:   isstart,
-		Bbsid:     bbsid,
+		ChatID:    chapterData.ChatID,
+		IsStart:   chapterData.IsStart,
+		Bbsid:     chapterData.BbsID,
 		Knowledge: knowledgeItems,
 	}
 	if len(chaptersList.Knowledge) == 0 {

--- a/aggregation/xuexitong/XueXiTongCourseAction.go
+++ b/aggregation/xuexitong/XueXiTongCourseAction.go
@@ -10,9 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	ddddocr "github.com/Changbaiqi/ddddocr-go/utils"
 	"github.com/thedevsaddam/gojsonq"
-	ort "github.com/yalue/onnxruntime_go"
 	"github.com/yatori-dev/yatori-go-core/api/xuexitong"
 	"github.com/yatori-dev/yatori-go-core/utils"
 	log2 "github.com/yatori-dev/yatori-go-core/utils/log"
@@ -57,27 +55,8 @@ func XueXiTPullCourseActionContext(ctx context.Context, cache *xuexitong.XueXiTU
 	//判断是否触发验证码
 	if strings.Contains(courses, "输入验证码") {
 		log2.Print(log2.DEBUG, utils.RunFuncName(), "触发验证码，正在进行AI智能识别绕过.....")
-		for {
-			img, err1 := cache.XueXiTVerificationCodeApi(7, nil)
-			if err1 != nil {
-				return nil, err1
-			}
-
-			_, width, _ := utils.GetImageShape(img)
-
-			var shape ort.Shape
-			if width == 140 {
-				shape = ort.NewShape(1, 23)
-			} else {
-				shape = ort.NewShape(1, 30)
-			}
-			codeResult := ddddocr.SemiOCRVerification(img, shape)
-			status, err1 := cache.XueXiTPassVerificationCode(codeResult, 7, nil)
-			//fmt.Println(codeResult)
-			//fmt.Println(status)
-			if status {
-				break
-			}
+		if err := passImageCaptcha(ctx, cache); err != nil {
+			return nil, fmt.Errorf("[%s] 课程验证码处理失败: %w", cache.Name, err)
 		}
 		courses, err = cache.CourseListApiContext(ctx, 3, nil)
 		if err != nil {

--- a/aggregation/xuexitong/XueXiTongCourseAction.go
+++ b/aggregation/xuexitong/XueXiTongCourseAction.go
@@ -2,6 +2,7 @@ package xuexitong
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -45,9 +46,13 @@ func (x *XueXiTCourse) ToString() string {
 
 // 拉取学习通所有课程列表并返回
 func XueXiTPullCourseAction(cache *xuexitong.XueXiTUserCache) ([]XueXiTCourse, error) {
-	courses, err := cache.CourseListApi(3, nil)
+	return XueXiTPullCourseActionContext(context.Background(), cache)
+}
+
+func XueXiTPullCourseActionContext(ctx context.Context, cache *xuexitong.XueXiTUserCache) ([]XueXiTCourse, error) {
+	courses, err := cache.CourseListApiContext(ctx, 3, nil)
 	if err != nil {
-		log2.Print(log2.INFO, "["+cache.Name+"] "+" 拉取失败")
+		return nil, fmt.Errorf("[%s] 拉取课程失败: %w", cache.Name, err)
 	}
 
 	//判断是否触发验证码
@@ -75,7 +80,10 @@ func XueXiTPullCourseAction(cache *xuexitong.XueXiTUserCache) ([]XueXiTCourse, e
 				break
 			}
 		}
-		courses, err = cache.CourseListApi(3, nil)
+		courses, err = cache.CourseListApiContext(ctx, 3, nil)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] 验证码通过后拉取课程失败: %w", cache.Name, err)
+		}
 		log2.Print(log2.DEBUG, utils.RunFuncName(), "绕过成功")
 	}
 
@@ -153,7 +161,10 @@ func XueXiTPullCourseAction(cache *xuexitong.XueXiTUserCache) ([]XueXiTCourse, e
 			courseListQueryData += ","
 		}
 	}
-	courseStatusListJson, err := cache.CourseCompleteStatusApi(courseListQueryData, 5, nil)
+	courseStatusListJson, err := cache.CourseCompleteStatusApiContext(ctx, courseListQueryData, 5, nil)
+	if err != nil {
+		return nil, fmt.Errorf("[%s] 拉取课程完成状态失败: %w", cache.Name, err)
+	}
 	courseStatusList := gojsonq.New().JSONString(courseStatusListJson).Find("jobArray")
 	//fmt.Println(courseStatusList)
 	if courseStatusList == nil {
@@ -196,8 +207,12 @@ type KnowledgeItem struct {
 
 // PullCourseChapterAction 获取对应课程的章节信息包括节点信息
 func PullCourseChapterAction(cache *xuexitong.XueXiTUserCache, cpi, key int) (chaptersList ChaptersList, ok bool, err error) {
+	return PullCourseChapterActionContext(context.Background(), cache, cpi, key)
+}
+
+func PullCourseChapterActionContext(ctx context.Context, cache *xuexitong.XueXiTUserCache, cpi, key int) (chaptersList ChaptersList, ok bool, err error) {
 	//拉取对应课程的章节信息
-	chapter, err := cache.PullChapter(cpi, key, 3, nil)
+	chapter, err := cache.PullChapterContext(ctx, cpi, key, 3, nil)
 	if err != nil {
 		return ChaptersList{}, false, errors.New("[" + cache.Name + "] " + " 拉取章节失败" + err.Error())
 	}
@@ -335,9 +350,17 @@ func ChapterFetchPointAction(cache *xuexitong.XueXiTUserCache,
 	chapters *ChaptersList,
 	clazzID, userID, cpi, courseID int,
 ) (ChaptersList, error) {
-	status, err := cache.FetchChapterPointStatus(nodes, clazzID, userID, cpi, courseID, 3, nil)
+	return ChapterFetchPointActionContext(context.Background(), cache, nodes, chapters, clazzID, userID, cpi, courseID)
+}
+
+func ChapterFetchPointActionContext(ctx context.Context, cache *xuexitong.XueXiTUserCache,
+	nodes []int,
+	chapters *ChaptersList,
+	clazzID, userID, cpi, courseID int,
+) (ChaptersList, error) {
+	status, err := cache.FetchChapterPointStatusContext(ctx, nodes, clazzID, userID, cpi, courseID, 3, nil)
 	if err != nil {
-		log2.Print(log2.DEBUG, "["+cache.Name+"] "+" 获取章节状态失败")
+		return ChaptersList{}, fmt.Errorf("[%s] 获取章节状态失败: %w", cache.Name, err)
 	}
 	var cp ChapterPointDTO
 	if err := json.NewDecoder(bytes.NewReader([]byte(status))).Decode(&cp); err != nil {

--- a/aggregation/xuexitong/XueXiTongExamAction.go
+++ b/aggregation/xuexitong/XueXiTongExamAction.go
@@ -2,6 +2,7 @@ package xuexitong
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -214,16 +215,11 @@ func EnterExamAction(cache *xuexitong.XueXiTUserCache, exam *XXTExam) error {
 			CaptchaId: exam.CaptchaCaptchaId,
 			Referer:   refererUrl,
 		}
-		for {
-			validate, passErr := slider.Pass(cache)
-			if passErr != nil {
-				if strings.Contains(passErr.Error(), `"result":false`) {
-					continue
-				}
-			}
-			exam.Validate = validate
-			break //如果成功了那么直接退出循环
+		validate, passErr := passSliderCaptcha(context.Background(), cache, &slider)
+		if passErr != nil {
+			return fmt.Errorf("考试滑块验证码处理失败: %w", passErr)
 		}
+		exam.Validate = validate
 	}
 	//如果是重考状态那么就先进行重考请求
 	if isReExam {

--- a/aggregation/xuexitong/XueXiTongExamAction.go
+++ b/aggregation/xuexitong/XueXiTongExamAction.go
@@ -88,7 +88,7 @@ func PullExamListAction(cache *xuexitong.XueXiTUserCache, course XueXiTCourse) (
 	}
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(examListHtml))
 	if err != nil {
-		log.Fatal(err)
+		return examList, fmt.Errorf("解析考试列表失败: %w", err)
 	}
 
 	// 遍历所有 <li>
@@ -148,16 +148,19 @@ func EnterExamAction(cache *xuexitong.XueXiTUserCache, exam *XXTExam) error {
 	//记得处理上面这个情况
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(enterHtml))
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("解析考试入口失败: %w", err)
 	}
 	isReExam := false
 	//如果可以重考
 	if strings.Contains(enterHtml, `bnt_retake">重考</a>`) {
 		reExamUrl, _ := doc.Find("a.bnt_retake").Attr("data")
 		enterHtml, err = cache.PullReExamPaperHtmlApi(reExamUrl)
+		if err != nil {
+			return fmt.Errorf("拉取重考页面失败: %w", err)
+		}
 		doc, err = goquery.NewDocumentFromReader(strings.NewReader(enterHtml))
 		if err != nil {
-			log.Fatal(err)
+			return fmt.Errorf("解析重考页面失败: %w", err)
 		}
 		isReExam = true
 	}
@@ -321,7 +324,7 @@ func (question *XXTExamQuestion) WriteQuestionForXXTAIAction(cache *xuexitong.Xu
 
 	aiAnswer, err := cache.XueXiTongAIAggregation(classId, courseId, cpi, aiChatMessages)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("学习通 AI 答题失败: %w", err)
 	}
 	var answers []string
 	err = json.Unmarshal([]byte(aiAnswer), &answers)
@@ -355,7 +358,7 @@ func HtmlQuestionTurnEntity(paperHtml string) (XXTExamQuestion, error) {
 	// 使用 goquery 解析 HTML
 	paperDoc, err := goquery.NewDocumentFromReader(bytes.NewReader([]byte(paperHtml)))
 	if err != nil {
-		log.Fatal(err)
+		return question, fmt.Errorf("解析考试题目失败: %w", err)
 	}
 	questionId, exists := paperDoc.Find("#questionId").Attr("value") //题目id
 	if exists {

--- a/aggregation/xuexitong/XueXiTongSliderAction.go
+++ b/aggregation/xuexitong/XueXiTongSliderAction.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"math"
 	"regexp"
+	"strings"
 
 	"github.com/thedevsaddam/gojsonq"
 	xuexitongApi "github.com/yatori-dev/yatori-go-core/api/xuexitong"
@@ -43,7 +44,7 @@ func (slider *XueXiTSlider) Pass(cache *xuexitongApi.XueXiTUserCache) (string, e
 	imgRe := regexp.MustCompile(`cx_captcha_function\((\{.*\})\)`)
 	m := imgRe.FindStringSubmatch(captchaImgResult)
 	if len(m) < 2 {
-		panic("JSON not found")
+		return "", fmt.Errorf("滑块图片响应缺少 JSON: %s", responseSummary(captchaImgResult))
 	}
 
 	jsonStr := m[1]
@@ -60,7 +61,7 @@ func (slider *XueXiTSlider) Pass(cache *xuexitongApi.XueXiTUserCache) (string, e
 	var resp CaptchaResponse
 	err1 := json.Unmarshal([]byte(jsonStr), &resp)
 	if err1 != nil {
-		panic(err)
+		return "", fmt.Errorf("解析滑块图片响应失败: %w", err1)
 	}
 
 	//fmt.Println("Token:", resp.Token)
@@ -95,7 +96,7 @@ func (slider *XueXiTSlider) Pass(cache *xuexitongApi.XueXiTUserCache) (string, e
 	passResultRe := regexp.MustCompile(`cx_captcha_function\((\{.*\})\)`)
 	submatchPass := passResultRe.FindStringSubmatch(passResult)
 	if len(submatchPass) < 2 {
-		panic("JSON not found")
+		return "", fmt.Errorf("滑块验证响应缺少 JSON: %s", responseSummary(passResult))
 	}
 
 	passJsonStr := submatchPass[1]
@@ -104,19 +105,35 @@ func (slider *XueXiTSlider) Pass(cache *xuexitongApi.XueXiTUserCache) (string, e
 			// 第一层：解析整个 JSON
 			extra := gojsonq.New().JSONString(passJsonStr).Find("extraData")
 			if extra == nil {
-				panic("extraData 为空")
+				return "", errors.New("滑块验证响应缺少 extraData")
 			}
 			// extra 是一个 string，需要再解析一遍
-			extraJson := extra.(string)
+			extraJson, ok := extra.(string)
+			if !ok {
+				return "", fmt.Errorf("滑块验证 extraData 类型异常: %T", extra)
+			}
 			// 第二层：从 extraJson 里取 validate
 			validate := gojsonq.New().JSONString(extraJson).Find("validate")
 			if validate == nil {
-				panic("validate 为空")
+				return "", errors.New("滑块验证响应缺少 validate")
 			}
-			return validate.(string), nil
+			validateString, ok := validate.(string)
+			if !ok || validateString == "" {
+				return "", fmt.Errorf("滑块验证 validate 类型异常: %T", validate)
+			}
+			return validateString, nil
 		}
 	}
 	return "", errors.New(passResult)
+}
+
+func responseSummary(value string) string {
+	const limit = 256
+	summary := strings.Join(strings.Fields(value), " ")
+	if len(summary) > limit {
+		return summary[:limit] + "..."
+	}
+	return summary
 }
 
 // 灰度化

--- a/aggregation/xuexitong/captcha_retry.go
+++ b/aggregation/xuexitong/captcha_retry.go
@@ -1,0 +1,85 @@
+package xuexitong
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	ddddocr "github.com/Changbaiqi/ddddocr-go/utils"
+	ort "github.com/yalue/onnxruntime_go"
+	xuexitongApi "github.com/yatori-dev/yatori-go-core/api/xuexitong"
+	"github.com/yatori-dev/yatori-go-core/utils"
+)
+
+const defaultCaptchaAttempts = 5
+
+type CaptchaRetryError struct {
+	Kind     string
+	Attempts int
+	LastErr  error
+}
+
+func (e *CaptchaRetryError) Error() string {
+	if e.LastErr == nil {
+		return fmt.Sprintf("%s重试 %d 次后仍未通过", e.Kind, e.Attempts)
+	}
+	return fmt.Sprintf("%s重试 %d 次后仍未通过: %v", e.Kind, e.Attempts, e.LastErr)
+}
+
+func (e *CaptchaRetryError) Unwrap() error {
+	return e.LastErr
+}
+
+func retryCaptcha(ctx context.Context, kind string, attempts int, attempt func() (bool, error)) error {
+	if attempts <= 0 {
+		return &CaptchaRetryError{Kind: kind, Attempts: attempts, LastErr: errors.New("未配置重试次数")}
+	}
+	var lastErr error
+	for index := 0; index < attempts; index++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		passed, err := attempt()
+		if passed {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = errors.New("验证码被拒绝")
+		}
+	}
+	return &CaptchaRetryError{Kind: kind, Attempts: attempts, LastErr: lastErr}
+}
+
+func passImageCaptcha(ctx context.Context, cache *xuexitongApi.XueXiTUserCache) error {
+	return retryCaptcha(ctx, "图片验证码", defaultCaptchaAttempts, func() (bool, error) {
+		img, err := cache.XueXiTVerificationCodeApi(7, nil)
+		if err != nil {
+			return false, err
+		}
+		_, width, _ := utils.GetImageShape(img)
+		shape := ort.NewShape(1, 30)
+		if width == 140 {
+			shape = ort.NewShape(1, 23)
+		}
+		codeResult := ddddocr.SemiOCRVerification(img, shape)
+		return cache.XueXiTPassVerificationCode(codeResult, 7, nil)
+	})
+}
+
+func passSliderCaptcha(ctx context.Context, cache *xuexitongApi.XueXiTUserCache, slider *XueXiTSlider) (string, error) {
+	var validate string
+	err := retryCaptcha(ctx, "滑块验证码", defaultCaptchaAttempts, func() (bool, error) {
+		value, err := slider.Pass(cache)
+		if err != nil {
+			return false, err
+		}
+		if value == "" {
+			return false, errors.New("滑块验证成功响应缺少 validate")
+		}
+		validate = value
+		return true, nil
+	})
+	return validate, err
+}

--- a/aggregation/xuexitong/captcha_retry_test.go
+++ b/aggregation/xuexitong/captcha_retry_test.go
@@ -1,0 +1,44 @@
+package xuexitong
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRetryCaptchaStopsAfterSuccess(t *testing.T) {
+	attempts := 0
+	err := retryCaptcha(context.Background(), "图片验证码", 5, func() (bool, error) {
+		attempts++
+		return attempts == 3, nil
+	})
+	if err != nil || attempts != 3 {
+		t.Fatalf("attempts=%d, err=%v", attempts, err)
+	}
+}
+
+func TestRetryCaptchaReturnsLastRejection(t *testing.T) {
+	attempts := 0
+	err := retryCaptcha(context.Background(), "滑块验证码", 3, func() (bool, error) {
+		attempts++
+		return false, errors.New("业务拒绝: 风控")
+	})
+	var retryErr *CaptchaRetryError
+	if !errors.As(err, &retryErr) || attempts != 3 || !strings.Contains(err.Error(), "业务拒绝: 风控") {
+		t.Fatalf("attempts=%d, err=%v", attempts, err)
+	}
+}
+
+func TestRetryCaptchaHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	attempts := 0
+	err := retryCaptcha(ctx, "图片验证码", 5, func() (bool, error) {
+		attempts++
+		return false, nil
+	})
+	if !errors.Is(err, context.Canceled) || attempts != 0 {
+		t.Fatalf("attempts=%d, err=%v", attempts, err)
+	}
+}

--- a/api/xuexitong/CardEntity.go
+++ b/api/xuexitong/CardEntity.go
@@ -285,10 +285,18 @@ func (d PointBBsDto) GetType() ctype.CardType { return d.Type }
 func (d PointBBsDto) IsSetted() bool          { return d.IsSet }
 
 // AttachmentsDetection 使用接口对每种DTO进行检测再次赋值, 以对应后续的刷取请求
-func (p *PointVideoDto) AttachmentsDetection(attachment interface{}) (bool, error) {
+func recoverAttachmentDetection(kind string, detected *bool, err *error) {
+	if recovered := recover(); recovered != nil {
+		*detected = false
+		*err = fmt.Errorf("%s Attachment 数据结构异常: %v", kind, recovered)
+	}
+}
+
+func (p *PointVideoDto) AttachmentsDetection(attachment interface{}) (detected bool, err error) {
+	defer recoverAttachmentDetection("视频", &detected, &err)
 	attachmentMap, ok := attachment.(map[string]interface{})
 	if !ok {
-		return false, errors.New("无法将 Attachment 转换为 map[string]interface{}")
+		return false, fmt.Errorf("视频 Attachment 根节点类型异常: %T", attachment)
 	}
 	attachments, ok := attachmentMap["attachments"].([]interface{})
 	if !ok {
@@ -296,7 +304,10 @@ func (p *PointVideoDto) AttachmentsDetection(attachment interface{}) (bool, erro
 	}
 
 	for _, a := range attachments {
-		attachment, _ := a.(map[string]interface{})
+		attachment, ok := a.(map[string]interface{})
+		if !ok {
+			return false, fmt.Errorf("视频 Attachment 子项类型异常: %T", a)
+		}
 		property, ok := attachment["property"].(map[string]interface{})
 		if !ok {
 			return false, errors.New("invalid property structure")
@@ -324,7 +335,11 @@ func (p *PointVideoDto) AttachmentsDetection(attachment interface{}) (bool, erro
 
 			var otherInfo string
 
-			parts := strings.SplitN(attachment["otherInfo"].(string), "&", 2)
+			otherInfoValue, ok := attachment["otherInfo"].(string)
+			if !ok {
+				return false, fmt.Errorf("视频 Attachment otherInfo 类型异常: %T", attachment["otherInfo"])
+			}
+			parts := strings.SplitN(otherInfoValue, "&", 2)
 			if len(parts) > 0 {
 				otherInfo = parts[0]
 			}
@@ -413,25 +428,39 @@ func (p *PointVideoDto) AttachmentsDetection(attachment interface{}) (bool, erro
 		}
 	}
 	if p.Attachment == nil {
-		p.Logger.Println("Failed to locate resource")
+		if p.Logger != nil {
+			p.Logger.Println("Failed to locate resource")
+		}
 		return false, nil
 	}
 	defaults, ok := attachmentMap["defaults"].(map[string]interface{})
 	if !ok {
 		return false, errors.New("invalid defaults structure")
 	}
-	fid, _ := strconv.Atoi(defaults["fid"].(string))
+	fidValue, ok := defaults["fid"].(string)
+	if !ok {
+		return false, fmt.Errorf("视频 Attachment defaults.fid 类型异常: %T", defaults["fid"])
+	}
+	fid, err := strconv.Atoi(fidValue)
+	if err != nil {
+		return false, fmt.Errorf("视频 Attachment defaults.fid 无效: %w", err)
+	}
 	p.FID = fid
-	p.PUID = defaults["userid"].(string)
+	userid, ok := defaults["userid"].(string)
+	if !ok {
+		return false, fmt.Errorf("视频 Attachment defaults.userid 类型异常: %T", defaults["userid"])
+	}
+	p.PUID = userid
 
 	return true, nil
 }
 
-func (p *PointWorkDto) AttachmentsDetection(attachment interface{}) (bool, error) {
+func (p *PointWorkDto) AttachmentsDetection(attachment interface{}) (detected bool, err error) {
+	defer recoverAttachmentDetection("作业", &detected, &err)
 	attachmentMap, ok := attachment.(map[string]interface{})
 	var flag bool
 	if !ok {
-		return false, errors.New("无法将 Attachment 转换为 map[string]interface{}")
+		return false, fmt.Errorf("作业 Attachment 根节点类型异常: %T", attachment)
 	}
 	attachments, ok := attachmentMap["attachments"].([]interface{})
 	if !ok {
@@ -475,10 +504,11 @@ func (p *PointWorkDto) AttachmentsDetection(attachment interface{}) (bool, error
 	return flag, nil
 }
 
-func (p *PointDocumentDto) AttachmentsDetection(attachment interface{}) (bool, error) {
+func (p *PointDocumentDto) AttachmentsDetection(attachment interface{}) (detected bool, err error) {
+	defer recoverAttachmentDetection("文档", &detected, &err)
 	attachmentMap, ok := attachment.(map[string]interface{})
 	if !ok {
-		return false, errors.New("无法将 Attachment 转换为 map[string]interface{}")
+		return false, fmt.Errorf("文档 Attachment 根节点类型异常: %T", attachment)
 	}
 	attachments, ok := attachmentMap["attachments"].([]interface{})
 	if !ok {
@@ -602,10 +632,11 @@ func (p *PointDocumentDto) AttachmentsDetection(attachment interface{}) (bool, e
 	return true, nil
 }
 
-func (p *PointHyperlinkDto) AttachmentsDetection(attachment interface{}) (bool, error) {
+func (p *PointHyperlinkDto) AttachmentsDetection(attachment interface{}) (detected bool, err error) {
+	defer recoverAttachmentDetection("外链", &detected, &err)
 	attachmentMap, ok := attachment.(map[string]interface{})
 	if !ok {
-		return false, errors.New("无法将 Attachment 转换为 map[string]interface{}")
+		return false, fmt.Errorf("外链 Attachment 根节点类型异常: %T", attachment)
 	}
 	attachments, ok := attachmentMap["attachments"].([]interface{})
 	if !ok {
@@ -639,10 +670,11 @@ func (p *PointHyperlinkDto) AttachmentsDetection(attachment interface{}) (bool, 
 }
 
 // 直播卡片
-func (p *PointLiveDto) AttachmentsDetection(attachment interface{}) (bool, error) {
+func (p *PointLiveDto) AttachmentsDetection(attachment interface{}) (detected bool, err error) {
+	defer recoverAttachmentDetection("直播", &detected, &err)
 	attachmentMap, ok := attachment.(map[string]interface{})
 	if !ok {
-		return false, errors.New("无法将 Attachment 转换为 map[string]interface{}")
+		return false, fmt.Errorf("直播 Attachment 根节点类型异常: %T", attachment)
 	}
 	attachments, ok := attachmentMap["attachments"].([]interface{})
 	if !ok {
@@ -699,10 +731,11 @@ func (p *PointLiveDto) AttachmentsDetection(attachment interface{}) (bool, error
 }
 
 // 直播卡片
-func (p *PointBBsDto) AttachmentsDetection(attachment interface{}) (bool, error) {
+func (p *PointBBsDto) AttachmentsDetection(attachment interface{}) (detected bool, err error) {
+	defer recoverAttachmentDetection("讨论", &detected, &err)
 	attachmentMap, ok := attachment.(map[string]interface{})
 	if !ok {
-		return false, errors.New("无法将 Attachment 转换为 map[string]interface{}")
+		return false, fmt.Errorf("讨论 Attachment 根节点类型异常: %T", attachment)
 	}
 	attachments, ok := attachmentMap["attachments"].([]interface{})
 	if !ok {

--- a/api/xuexitong/XueXiTongChapterApi.go
+++ b/api/xuexitong/XueXiTongChapterApi.go
@@ -1,6 +1,7 @@
 package xuexitong
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -19,6 +20,10 @@ import (
 // cpi ? key ?? ????json?????? int
 // TODO???? int ???????? ?Course???????? ? ?action?????XueXiTCourseDetailForCourseIdAction???? ???
 func (cache *XueXiTUserCache) PullChapter(cpi int, key int, retry int, lastErr error) (string, error) {
+	return cache.PullChapterContext(context.Background(), cpi, key, retry, lastErr)
+}
+
+func (cache *XueXiTUserCache) PullChapterContext(ctx context.Context, cpi int, key int, retry int, lastErr error) (string, error) {
 	if retry < 0 {
 		return "", lastErr
 	}
@@ -40,10 +45,8 @@ func (cache *XueXiTUserCache) PullChapter(cpi int, key int, retry int, lastErr e
 			return url.Parse("http://" + cache.ProxyIP) // 设置代理
 		}
 	}
-	client := &http.Client{
-		Transport: tr,
-	}
-	req, err := http.NewRequest(method, "https://mooc1-api.chaoxing.com/gas/clazz"+"?"+params.Encode(), nil)
+	client := newRequestClient(tr)
+	req, err := http.NewRequestWithContext(ctx, method, "https://mooc1-api.chaoxing.com/gas/clazz"+"?"+params.Encode(), nil)
 
 	if err != nil {
 		fmt.Println(err)
@@ -59,16 +62,19 @@ func (cache *XueXiTUserCache) PullChapter(cpi int, key int, retry int, lastErr e
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		time.Sleep(time.Duration(retry*5) * time.Second)
-		//fmt.Println(err)
-		//return "", err
-		return cache.PullChapter(cpi, key, retry-1, err)
+		if waitErr := waitForRetry(ctx, time.Duration(retry*5)*time.Second); waitErr != nil {
+			return "", waitErr
+		}
+		return cache.PullChapterContext(ctx, cpi, key, retry-1, err)
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		fmt.Println(err)
+		return "", err
+	}
+	if err := validateResponse("拉取课程章节", res, body); err != nil {
 		return "", err
 	}
 	utils.CookiesAddNoRepetition(&cache.cookies, res.Cookies()) //赋值cookie
@@ -78,6 +84,10 @@ func (cache *XueXiTUserCache) PullChapter(cpi int, key int, retry int, lastErr e
 // FetchChapterPointStatus 章节状态
 // nodes 各章节对应ID
 func (cache *XueXiTUserCache) FetchChapterPointStatus(nodes []int, clazzID, userID, cpi, courseID int, retry int, lastErr error) (string, error) {
+	return cache.FetchChapterPointStatusContext(context.Background(), nodes, clazzID, userID, cpi, courseID, retry, lastErr)
+}
+
+func (cache *XueXiTUserCache) FetchChapterPointStatusContext(ctx context.Context, nodes []int, clazzID, userID, cpi, courseID int, retry int, lastErr error) (string, error) {
 	if retry < 0 {
 		return "", lastErr
 	}
@@ -111,10 +121,8 @@ func (cache *XueXiTUserCache) FetchChapterPointStatus(nodes []int, clazzID, user
 			return url.Parse("http://" + cache.ProxyIP) // 设置代理
 		}
 	}
-	client := &http.Client{
-		Transport: tr,
-	}
-	req, err := http.NewRequest(method, "https://mooc1-api.chaoxing.com/job/myjobsnodesmap", payload)
+	client := newRequestClient(tr)
+	req, err := http.NewRequestWithContext(ctx, method, "https://mooc1-api.chaoxing.com/job/myjobsnodesmap", payload)
 
 	if err != nil {
 		fmt.Println(err)
@@ -131,15 +139,19 @@ func (cache *XueXiTUserCache) FetchChapterPointStatus(nodes []int, clazzID, user
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		//fmt.Println(err)
-		time.Sleep(time.Duration(retry*5) * time.Second)
-		return cache.FetchChapterPointStatus(nodes, clazzID, userID, cpi, courseID, retry-1, err)
+		if waitErr := waitForRetry(ctx, time.Duration(retry*5)*time.Second); waitErr != nil {
+			return "", waitErr
+		}
+		return cache.FetchChapterPointStatusContext(ctx, nodes, clazzID, userID, cpi, courseID, retry-1, err)
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		fmt.Println(err)
+		return "", err
+	}
+	if err := validateResponse("拉取章节任务点状态", res, body); err != nil {
 		return "", err
 	}
 	// 解码响应体（假设服务器返回的内容是 ISO-8859-1 编码）

--- a/api/xuexitong/XueXiTongCourseApi.go
+++ b/api/xuexitong/XueXiTongCourseApi.go
@@ -3,19 +3,22 @@ package xuexitong
 //注意Api类文件主需要写最原始的接口请求和最后的json的string形式返回，不需要用结构体序列化。
 //序列化和具体的功能实现请移步到Action代码文件中
 import (
+	"context"
 	"crypto/tls"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/yatori-dev/yatori-go-core/utils"
-	"github.com/yatori-dev/yatori-go-core/utils/log"
 )
 
 // CourseListApi 拉取对应账号的课程数据
 func (cache *XueXiTUserCache) CourseListApi(retry int, lastErr error) (string, error) {
+	return cache.CourseListApiContext(context.Background(), retry, lastErr)
+}
+
+func (cache *XueXiTUserCache) CourseListApiContext(ctx context.Context, retry int, lastErr error) (string, error) {
 	if retry < 0 {
 		return "", lastErr
 	}
@@ -31,10 +34,8 @@ func (cache *XueXiTUserCache) CourseListApi(retry int, lastErr error) (string, e
 			return url.Parse("http://" + cache.ProxyIP) // 设置代理
 		}
 	}
-	client := &http.Client{
-		Transport: tr,
-	}
-	req, err := http.NewRequest(method, "https://mooc1-api.chaoxing.com/mycourse/backclazzdata", nil)
+	client := newRequestClient(tr)
+	req, err := http.NewRequestWithContext(ctx, method, "https://mooc1-api.chaoxing.com/mycourse/backclazzdata", nil)
 
 	if err != nil {
 		return "", err
@@ -55,28 +56,36 @@ func (cache *XueXiTUserCache) CourseListApi(retry int, lastErr error) (string, e
 	if err != nil {
 		return "", err
 	}
+	if err := validateResponse("拉取课程列表", res, body); err != nil {
+		return "", err
+	}
 	if strings.Contains(string(body), "很抱歉，您所浏览的页面不存在") { //防止学习通抽风
-		return cache.CourseListApi(retry-1, err)
+		lastErr = &RemoteError{Operation: "拉取课程列表", StatusCode: res.StatusCode, BodySummary: responseSummary(body)}
+		return cache.CourseListApiContext(ctx, retry-1, lastErr)
 	}
 	return string(body), nil
 }
 
 // 拉取课程完成度状态
 func (cache *XueXiTUserCache) CourseCompleteStatusApi(courseListData string, retry int, lastErr error) (string, error) {
+	return cache.CourseCompleteStatusApiContext(context.Background(), courseListData, retry, lastErr)
+}
+
+func (cache *XueXiTUserCache) CourseCompleteStatusApiContext(ctx context.Context, courseListData string, retry int, lastErr error) (string, error) {
+	if retry < 0 {
+		return "", lastErr
+	}
 	urlStr := "https://mooc2-ans.chaoxing.com/mooc2-ans/mycourse/stu-job-info?clazzPersonStr=" + url.QueryEscape(courseListData)
 	//urlStr := "https://mooc2-ans.chaoxing.com/mooc2-ans/mycourse/stu-job-info?clazzPersonStr=134350229_407555221%252C125743273_407555221%252C127063689_407555221%252C126701067_407555221%252C125755386_407555221%252C125888882_407555221%252C125783661_454194591%252C124859308_454194591%252C124554421_454194591%252C116272688_407555221%252C117108284_407555221%252C117784832_407555221%252C116370785_407555221%252C116370660_407555221%252C117687599_407555221"
 	method := "GET"
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{},
 	}
-	client := &http.Client{
-		Transport: tr,
-	}
-	req, err := http.NewRequest(method, urlStr, nil)
+	client := newRequestClient(tr)
+	req, err := http.NewRequestWithContext(ctx, method, urlStr, nil)
 
 	if err != nil {
-		log.Print(log.INFO, fmt.Sprintf("[%s]", cache.Name), err.Error())
-		return "", nil
+		return "", err
 	}
 	req.Header.Add("Accept", "application/json, text/javascript, */*; q=0.01")
 	req.Header.Add("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6")
@@ -100,15 +109,16 @@ func (cache *XueXiTUserCache) CourseCompleteStatusApi(courseListData string, ret
 
 	res, err := client.Do(req)
 	if err != nil {
-		log.Print(log.INFO, fmt.Sprintf("[%s]", cache.Name), err.Error())
-		return "", nil
+		return "", err
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		log.Print(log.INFO, fmt.Sprintf("[%s]", cache.Name), err.Error())
-		return "", nil
+		return "", err
+	}
+	if err := validateResponse("拉取课程完成状态", res, body); err != nil {
+		return "", err
 	}
 	return string(body), nil
 }

--- a/api/xuexitong/XueXiTongVerCodeApi.go
+++ b/api/xuexitong/XueXiTongVerCodeApi.go
@@ -39,9 +39,7 @@ func (cache *XueXiTUserCache) XueXiTVerificationCodeApi(retry int, lastErr error
 			return url.Parse("http://" + cache.ProxyIP) // 设置代理
 		}
 	}
-	client := &http.Client{
-		Transport: tr,
-	}
+	client := newRequestClient(tr)
 	req, err := http.NewRequest(method, urlStr, nil)
 
 	if err != nil {
@@ -283,9 +281,7 @@ func (cache *XueXiTUserCache) XueXiTSliderVerificationCodeApi(captchaId string, 
 			return url.Parse("http://" + cache.ProxyIP) // 设置代理
 		}
 	}
-	client := &http.Client{
-		Transport: tr,
-	}
+	client := newRequestClient(tr)
 	req, err := http.NewRequest(method, urlStr, nil)
 
 	if err != nil {
@@ -439,9 +435,7 @@ func (cache *XueXiTUserCache) PassSliderApi(captchaId, token, xPoint, runEnv str
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{},
 	}
-	client := &http.Client{
-		Transport: tr,
-	}
+	client := newRequestClient(tr)
 	req, err := http.NewRequest(method, urlStr, nil)
 
 	if err != nil {
@@ -449,10 +443,8 @@ func (cache *XueXiTUserCache) PassSliderApi(captchaId, token, xPoint, runEnv str
 		return "", err
 	}
 	req.Header.Add("User-Agent", "Mozilla/5.0 (Linux; Android 8.1.0; MI 5X Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36 (schild:ce5175d20950c8ee955fb03246f762da) (device:MI 5X) Language/zh_CN com.chaoxing.mobile/ChaoXingStudy_3_6.7.2_android_phone_10936_311 (@Kalimdor)_76c82452584d47e39ab79aa54ea86554")
-	req.Header.Add("Referer", "https://mooc1-api.chaoxing.com/exam-ans/exam/phone/task-exam?taskrefId=8186945&courseId=258101827&classId=134204187&userId=346635955&role=&source=0&enc_task=e8a0e0f5b2faa978194ba2b19eef6371&cpi=411545273&vx=0")
 	req.Header.Add("Accept-Language", "zh-CN,en-US;q=0.9")
 	req.Header.Add("X-Requested-With", "com.chaoxing.mobile")
-	req.Header.Add("Cookie", "fid=10596; _uid=346635955; UID=346635955; xxtenc=f8c84ceb53bc45f40b7d9bfaaa413810; fidsCount=1; _industry=5; sso_role=3; _d=1764581587129; vc3=SAXTH83nW82I24XNPrYxTR5%2BqWzeoa5H0RVk%2Fx33Z349hIyGpA9YUXqdlIlSNELZLQDkdvX%2Bxt1tdBHmkWnKDnZe8uS9KNflmJeA%2BB2B%2BoFMHh4l2y7a%2BzavXJWhld5uy13Sp5sheSfr4YFX1L4HD3IDmP7CYaFudc1OIyBYFps%3D6f67ebf861ea9e237b52948f53712450; uf=b2d2c93beefa90dc495549838143a13b264677447b1a2384b8cd17c4874b05f5c7f0fc7ea8ee15fce6a8763e149e6bebc7ea6fb664318d21c49d67c0c30ca5043ad701c8b4cc548c0234d89f51c3dccfb0f1a1db51ab43f5fb98ce0e6210c3884a878d0a9a7b05da6103a97f8cd189bc7a1043b040b4578d56e259a2b85e0a6e3b2582f374bcb84576e6e30a0f14e5c5da9735baa04d8d5fce71fc6e59483dd39b16e3a7097306134bafd738ca9e0a89814fcc5587ad448be9fdc681bdf07734; cx_p_token=f0a5c5753305b13f72a633b249e68414; p_auth_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiIzNDY2MzU5NTUiLCJsb2dpblRpbWUiOjE3NjQ1ODE1ODcxMzEsImV4cCI6MTc2NTE4NjM4N30.3DTJuexTRsnpEjqvRMVENDTkzbDNZ5gQh2nD3zRMpSc; DSSTASH_LOG=C_38-UN_10038-US_346635955-T_1764581587132; sso_t=1764581587129; sso_v=6297276a0398c6cad732ad984a3edd46; KI4SO_SERVER_EC=RERFSWdRQWdsckJiQXZ5ZmdkWW10dG5IcktUZWdhbVU4b2FRY0NrVkVzQm1TME55eG5ya2NpR3J2%0ATW5ZQXhUK0RtU2djWlRjU2NTVQp1NG13bWtscWxlNXl4ZGk3WUJZckF5OVlCZjBBUTUwN3dlclJt%0ARDFtdWE0OVd4bXBHSTZoZFFXNy9qQlRKb2wzY1V2R0dNNjFTRWxPCjhKbkRyZHlUQjNPT1pld0pz%0ANjhyZFR3TFlKaDViZk5OU3pNajNvY29hcU12bVBycExsckV6TWJLYkEvdFhVaTgwMTYzRHRKZUd2%0ARUgKaW55cFE3ZW1aNW9oUGRsVWp6SHVORHFmVXE1ZFdlRXMxaUw1L05DNHhqSllPL3Q1STBLbUxW%0ASTBDK0ZjdUlETU1FSFVXTEJGeWpmQQpVbGo3MVc4K1F5STI1cFFaTTN1VGh6VmJrblFqRXNucjB4%0ANmxoQnNwdjJGNkhQcXcvdE5QWGhidVBpWmIxeEIvZ1F1NCtMaUF6REJCCjFGaXdSY28zd0ZKWSs5%0AVnZQa01pTnVhVUdkS0Y0RlI4bFpQcy9nQ2dHcHc2MTVQandySXhEY1BUSGIxMkpkUEN5VUxVTkNP%0AR3VhaEsKR05NPT9hcHBJZD0xJmtleUlkPTE%3D; _tid=300631019; sso_puid=346635955; route=c873910f23fdbb50ba156beee2b1b2db")
 	req.Header.Add("Accept", "*/*")
 	req.Header.Add("Host", "captcha.chaoxing.com")
 	req.Header.Add("Connection", "keep-alive")
@@ -467,6 +459,9 @@ func (cache *XueXiTUserCache) PassSliderApi(captchaId, token, xPoint, runEnv str
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		fmt.Println(err)
+		return "", err
+	}
+	if err := validateResponse("提交滑块验证码", res, body); err != nil {
 		return "", err
 	}
 	//fmt.Println(string(body))

--- a/api/xuexitong/card_entity_test.go
+++ b/api/xuexitong/card_entity_test.go
@@ -1,0 +1,30 @@
+package xuexitong
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVideoAttachmentDetectionReportsRootType(t *testing.T) {
+	_, err := (&PointVideoDto{}).AttachmentsDetection("business error")
+	if err == nil || !strings.Contains(err.Error(), "根节点类型异常: string") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVideoAttachmentDetectionRecoversMalformedNestedData(t *testing.T) {
+	attachment := map[string]interface{}{
+		"attachments": []interface{}{
+			map[string]interface{}{
+				"property":  map[string]interface{}{"objectid": "video-1", "jobid": "job-1"},
+				"otherInfo": 42,
+			},
+		},
+		"defaults": map[string]interface{}{"fid": "1", "userid": "2"},
+	}
+	point := &PointVideoDto{ObjectID: "video-1", JobID: "job-1"}
+	_, err := point.AttachmentsDetection(attachment)
+	if err == nil || !strings.Contains(err.Error(), "otherInfo 类型异常") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/api/xuexitong/request_boundary.go
+++ b/api/xuexitong/request_boundary.go
@@ -1,0 +1,116 @@
+package xuexitong
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultRequestTimeout = 30 * time.Second
+
+// RemoteError preserves enough response context to distinguish HTTP failures from business rejections.
+type RemoteError struct {
+	Operation   string
+	StatusCode  int
+	ContentType string
+	Message     string
+	BodySummary string
+}
+
+func (e *RemoteError) Error() string {
+	parts := []string{e.Operation}
+	if e.StatusCode != 0 {
+		parts = append(parts, fmt.Sprintf("HTTP %d", e.StatusCode))
+	}
+	if e.Message != "" {
+		parts = append(parts, e.Message)
+	}
+	if e.BodySummary != "" && e.BodySummary != e.Message {
+		parts = append(parts, "响应: "+e.BodySummary)
+	}
+	return strings.Join(parts, ": ")
+}
+
+func newRequestClient(transport http.RoundTripper) *http.Client {
+	return &http.Client{Transport: transport, Timeout: defaultRequestTimeout}
+}
+
+func validateResponse(operation string, response *http.Response, body []byte) error {
+	summary := responseSummary(body)
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return &RemoteError{
+			Operation:   operation,
+			StatusCode:  response.StatusCode,
+			ContentType: response.Header.Get("Content-Type"),
+			BodySummary: summary,
+		}
+	}
+
+	message, rejected := rejectedBusinessResponse(body)
+	if rejected {
+		return &RemoteError{
+			Operation:   operation,
+			StatusCode:  response.StatusCode,
+			ContentType: response.Header.Get("Content-Type"),
+			Message:     message,
+			BodySummary: summary,
+		}
+	}
+	return nil
+}
+
+func rejectedBusinessResponse(body []byte) (string, bool) {
+	trimmed := strings.TrimSpace(string(body))
+	if start, end := strings.Index(trimmed, "("), strings.LastIndex(trimmed, ")"); start >= 0 && end > start {
+		body = []byte(trimmed[start+1 : end])
+	}
+	var payload map[string]interface{}
+	if json.Unmarshal(body, &payload) != nil {
+		return "", false
+	}
+
+	rejected := false
+	for _, key := range []string{"status", "success", "result"} {
+		if value, exists := payload[key]; exists {
+			if status, ok := value.(bool); ok && !status {
+				rejected = true
+			}
+		}
+	}
+	if !rejected {
+		return "", false
+	}
+
+	for _, key := range []string{"msg", "message", "errorMsg", "error"} {
+		if message, ok := payload[key].(string); ok && strings.TrimSpace(message) != "" {
+			return strings.TrimSpace(message), true
+		}
+	}
+	return "业务请求被拒绝", true
+}
+
+func responseSummary(body []byte) string {
+	const limit = 512
+	summary := strings.Join(strings.Fields(string(body)), " ")
+	if len(summary) > limit {
+		return summary[:limit] + "..."
+	}
+	return summary
+}
+
+func waitForRetry(ctx context.Context, duration time.Duration) error {
+	if duration <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/api/xuexitong/request_boundary_test.go
+++ b/api/xuexitong/request_boundary_test.go
@@ -1,0 +1,51 @@
+package xuexitong
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestValidateResponsePreservesHTTPFailure(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+	err := validateResponse("拉取章节状态", response, []byte(`{"msg":"请求过于频繁"}`))
+	var remoteErr *RemoteError
+	if !errors.As(err, &remoteErr) {
+		t.Fatalf("expected RemoteError, got %T", err)
+	}
+	if remoteErr.StatusCode != http.StatusTooManyRequests || !strings.Contains(err.Error(), "请求过于频繁") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateResponsePreservesBusinessMessage(t *testing.T) {
+	response := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}
+	err := validateResponse("拉取课程", response, []byte(`{"status":false,"msg":"操作频繁，请稍后重试"}`))
+	var remoteErr *RemoteError
+	if !errors.As(err, &remoteErr) {
+		t.Fatalf("expected RemoteError, got %T", err)
+	}
+	if remoteErr.Message != "操作频繁，请稍后重试" {
+		t.Fatalf("unexpected message: %q", remoteErr.Message)
+	}
+}
+
+func TestValidateResponsePreservesJSONPBusinessMessage(t *testing.T) {
+	response := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}
+	err := validateResponse("提交滑块验证码", response, []byte(`cx_captcha_function({"result":false,"msg":"验证失败"})`))
+	var remoteErr *RemoteError
+	if !errors.As(err, &remoteErr) || remoteErr.Message != "验证失败" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateResponseAcceptsSuccessfulJSON(t *testing.T) {
+	response := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}
+	if err := validateResponse("拉取课程", response, []byte(`{"status":true,"result":true}`)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## 概述

该 PR 主要修复**学习通**请求异常、任务点解析崩溃和验证码无限重试

| 问题 | 修改前 | 修改后 |
| --- | --- | --- |
| 请求失败 | 吞掉报错 / 误报为 `课程或章节为空` | 返回 HTTP、业务拒绝、超时等详情原因 |
| 数据异常（字段缺失/类型变化） | 整个进程暴毙 | 返回错误信息而不是终止程序 |
| 验证码失败 | 无限重试 | 最多尝试 5 次并保留最后一次失败原因 |
| 固定账号信息 | 滑块请求带有写死的 Referer 和 Cookie | 删除固定会话信息，使用当前账号数据 |

~~（懒得拆 PR 了）~~

## 关键修复（数据异常）

> [!CAUTION]
>
> 学习通返回的 Attachment、章节 JSON 或卡片 HTML 缺字段、字段类型变化时
>
> 原代码存在类型断言 panic、`log.Fatal` 和**直接终止进程**的情况

现在改为~~温和地~~返回错误，例如：

- 视频、作业、文档、外链和直播 Attachment 结构异常
- 章节响应缺少 `data`、`course.data` 或任务点数据
- 卡片页面缺少 `AttachmentSetting`
- 章节尚未开放
- 作业、考试和滑块页面解析失败
- 学习通 AI 答题请求失败

---
其他依赖 yatori-go-core 的下游项目大概率会复现同样的问题，或许应该推一个 tag？